### PR TITLE
Updated what is asciidoctor document with content from news post

### DIFF
--- a/docs/what-is-asciidoctor.adoc
+++ b/docs/what-is-asciidoctor.adoc
@@ -42,7 +42,8 @@ Asciidoctor also offers several levels of security, further justifying its suita
 .Beyond Ruby
 Asciidoctor's usage is not limited to the Ruby community. 
 Thanks to http://jruby.org[JRuby], a port of Ruby to the JVM, Asciidoctor can be used inside Java applications as well.
-Plugins are available for {gh-org}/asciidoctor-maven-plugin[Apache Maven],  {gh-org}/asciidoctor-gradle-plugin[Gradle], and https://github.com/ocpsoft/rewrite/tree/master/transform-markup[Rewrite]. These plugins are based on the {gh-org}/asciidoctor-java-integration[Java integration library] for Asciidoctor. 
+Plugins are available for {gh-org}/asciidoctor-maven-plugin[Apache Maven],  {gh-org}/asciidoctor-gradle-plugin[Gradle], and https://github.com/ocpsoft/rewrite/tree/master/transform-markup[Rewrite].
+These plugins are based on the {gh-org}/asciidoctor-java-integration[Java integration library] for Asciidoctor. 
 
 Asciidoctor also ships with a command-line interface (cli). 
 The Asciidoctor cli, link:/man/asciidoctor/[+asciidoctor+], is a drop-in replacement for the +asciidoc.py+ script from the AsciiDoc Python distribution.
@@ -51,5 +52,3 @@ The Asciidoctor cli, link:/man/asciidoctor/[+asciidoctor+], is a drop-in replace
 
 Asciidoctor is published as a RubyGem and currently works with Ruby 1.8.7, Ruby 1.9.3, Ruby 2.0.0, JRuby 1.7.2 and Rubinius 1.2.4 on Linux, Mac and Windows. 
 We expect it will work with other versions of Ruby as well.
-
-


### PR DESCRIPTION
Content was copied from this blog post: http://asciidoctor.org/news/2013/01/30/asciidoc-returns-to-github/
