### PR TITLE
Asciidoclet guide from README

### DIFF
--- a/docs/install-and-use-asciidoclet.adoc
+++ b/docs/install-and-use-asciidoclet.adoc
@@ -1,0 +1,144 @@
+= Installing and Using Asciidoclet
+John Ericksen <https://github.com/johncarl81>
+v0.1.0
+:description: This is a guide for setting up and using the Asciidoclet project. Asciidoclet is a Javadoc Doclet based on Asciidoctor that lets you write Javadoc in the AsciiDoc syntax.
+:keywords: Asciidoclet, AsciiDoc, Asciidoctor, syntax, Javadoc, Doclet, reference
+:awestruct-layout: base
+:toc:
+:sectanchors:
+:icons: font
+:source-highlighter: highlight.js
+ifndef::awestruct[]
+:idprefix:
+:idseparator: -
+endif::awestruct[]
+:asciidoclet-git: https://github.com/asciidoctor/asciidoclet
+:asciidoc: http://asciidoc.org
+:asciidoctor-java-ref: http://asciidoctor.org/docs/install-and-use-asciidoctor-java-integration/
+:asciidoclet-issue: https://github.com/asciidoctor/asciidoclet/issues
+:asciidoctor-git: https://github.com/asciidoctor/asciidoctor
+:asciidoctor-java-git: https://github.com/asciidoctor/asciidoctor-java-integration
+:discuss-ref: http://discuss.asciidoctor.org/
+
+{asciidoclet-git}[Asciidoclet] is a Javadoc Doclet based on Asciidoctor that lets you write Javadoc in the AsciiDoc syntax.
+
+== Introduction
+
+Traditionally, Javadocs have mixed minor markup with HTML which, if you're writing for HTML Javadoc output, becomes unreadable and hard to write over time. 
+This is where lightweight markup languages like {asciidoc}[AsciiDoc] thrive. 
+AsciiDoc straddles the line between readable markup and beautifully rendered content.
+
+Asciidoclet incorporates an AsciiDoc renderer (Asciidoctor via the {asciidoctor-java-ref}[Asciidoctor Java integration] library) into a simple Doclet that enables AsciiDoc formatting within Javadoc comments and tags.
+
+== Example
+
+Here's an example of a class with traditional Javadoc.
+
+[source,java]
+.Traditional Javadoc class
+----
+/**
+ * <h1>Asciidoclet</h1>
+ *
+ * <p>Sample comments that include {@code source code}.</p>
+ *
+ * <pre>{@code
+ * public class Asciidoclet extends Doclet {
+ *     private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+ *
+ *     {@literal @}SuppressWarnings("UnusedDeclaration")
+ *     public static boolean start(RootDoc rootDoc) {
+ *         new Asciidoclet().render(rootDoc);
+ *         return Standard.start(rootDoc);
+ *     }
+ * }
+ * }</pre>
+ *
+ * @author <a href="https://github.com/johncarl81">John Ericksen</a>
+ */
+public class Asciidoclet extends Doclet {
+}
+----
+
+This is the same class with Asciidoclet.
+
+[source,java]
+.Asciidoclet class
+----
+/**
+ * = Asciidoclet
+ *
+ * Sample comments that include +source code+.
+ *
+ * [source,java]
+ * --
+ * public class Asciidoclet extends Doclet {
+ *     private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+ *
+ *     @SuppressWarnings("UnusedDeclaration")
+ *     public static boolean start(RootDoc rootDoc) {
+ *         new Asciidoclet().render(rootDoc);
+ *         return Standard.start(rootDoc);
+ *     }
+ * }
+ * --
+ *
+ * @author https://github.com/johncarl81[John Ericksen]
+ */
+public class Asciidoclet extends Doclet {
+}
+----
+
+The result is readable source and beautifully rendered Javadocs, the best of both worlds!
+
+== Usage
+
+Asciidoclet may be used via a +maven-javadoc-plugin+ doclet:
+
+[source,xml]
+----
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-javadoc-plugin</artifactId>
+    <version>2.9</version>
+    <configuration>
+        <source>1.7</source>
+        <doclet>org.asciidoctor.Asciidoclet</doclet>
+        <docletArtifact>
+            <groupId>org.asciidoclet</groupId>
+            <artifactId>asciidoclet</artifactId>
+            <version>${asciidoclet.version}</version>
+        </docletArtifact>
+    </configuration>
+</plugin>
+----
+
+== Rescources and help
+
+For more information:
+
+* {asciidoclet-git}[Asciidoclet Source Code]
+* {asciidoclet-issue}[Asciidoclet Issue Tracker]
+* {asciidoctor-git}[Asciidoctor Source Code]
+* {asciidoctor-java-git}[Asciidoctor Java Integration Source Code]
+
+If you have questions or would like to help develop this project, please join the {discuss-ref}[Asciidoctor discussion list].
+
+== License
+
+....
+Copyright 2013 John Ericksen
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+....
+


### PR DESCRIPTION
The Asciidoclet Guide, created from the repo's README, for website Docs page.

Next:

Will need to create a link on Docs index page, but what category should this be filed under?
