### PR TITLE
resolves #57 update table syntax in quick and writers docs

### DIFF
--- a/docs/asciidoc-syntax-quick-reference.adoc
+++ b/docs/asciidoc-syntax-quick-reference.adoc
@@ -1413,9 +1413,98 @@ Notice it's a delimited block.
 
 == Tables
 
-.Table with two rows of content and a header
+.Table with four columns, a header, and two rows of content
 ----
-[cols="1,1,2" options="header"]
+[options="header"]
+.Table of contents attributes and values
+|===
+|Attribute |Value(s) |Example Syntax |Comments <1>
+
+|toc
+|auto
+|+:toc:+
+|DocBook backend uses it by default.
+Disable the TOC with +:toc!:+.
+
+|toc2
+|auto
+|+:toc2:+
+|-
+|===
+----
+<1> The number of columns in a table is equal to the number of vertical bars on the first non-blank line of content inside the table block delimiters.
+
+[.result]
+====
+[options="header"]
+.Table of contents attributes and values
+|===
+|Attribute |Value(s) |Example Syntax |Comments <1>
+
+|toc
+|auto
+|+:toc:+
+|DocBook backend uses it by default.
+Disable the TOC with +:toc!:+.
+
+|toc2
+|auto
+|+:toc2:+
+|-
+|===
+====
+
+.Table with four columns, a header, and two rows of content
+----
+[cols="4*", options="header"] <1> <2>
+.Table of contents attributes and values
+|===
+|Attribute 
+|Value(s) 
+|Example Syntax 
+|Comments
+
+|toc
+|auto
+|+:toc:+
+|DocBook backend uses it by default.
+Disable the TOC with +:toc!:+.
+
+|toc2
+|auto
+|+:toc2:+
+|-
+|===
+----
+<1> When the column titles are not all specified on the first line, you must add the +cols+ attribute to the block attributes.
+<2> The +*+ is the repeat operator. It means to repeat the column specification for the remainder of columns. In this case, it means to repeat no special formatting (since none is present) across 4 columns.
+
+[.result]
+====
+[cols="4*", options="header"]
+.Table of contents attributes and values
+|===
+|Attribute 
+|Value(s) 
+|Example Syntax 
+|Comments
+
+|toc
+|auto
+|+:toc:+
+|DocBook backend uses it by default.
+Disable the TOC with +:toc!:+.
+
+|toc2
+|auto
+|+:toc2:+
+|-
+|===
+====
+
+.Table with three columns, a header, and two rows of content
+----
+[cols="1,1,2", options="header"] <1>
 .Applications
 |===
 |Name
@@ -1434,10 +1523,11 @@ performance, portability.
 Empowers developers to easily create real, automated tests.
 |===
 ----
+<1> In this example, the +cols+ attribute has two functions. It specifies that this table has three columns and sets their relative widths.
 
 [.result]
 ====
-[cols="1,1,2" options="header"]
+[cols="1,1,2", options="header"]
 .Applications
 |===
 |Name
@@ -1922,7 +2012,7 @@ Check out {homepagelink} too!
 
 .Counter attributes
 ----
-[cols="2", options="header", caption=""]
+[cols="2*", options="header", caption=""]
 .Parts{counter2:index:0}
 |===
 |Part Id
@@ -1938,7 +2028,7 @@ Check out {homepagelink} too!
 
 [.result]
 ====
-[cols="2", options="header", caption=""]
+[cols="2*", options="header", caption=""]
 .Parts{counter2:index:0}
 |===
 |Part Id

--- a/docs/asciidoc-writers-guide.adoc
+++ b/docs/asciidoc-writers-guide.adoc
@@ -551,7 +551,7 @@ Here's how the previous list renders:
 The following table shows the number scheme used by default for each nesting level:
 
 .Ordered list numbering scheme by level
-[cols="^2,3,3,4" options="header"]
+[cols="^2,3,3,4", options="header"]
 |===
 |Level |Numbering Scheme |Examples |CSS class (HTML backend)
 |1
@@ -1344,7 +1344,7 @@ Since a listing block is typically used for source code, substitutions are not d
 
 The following table identifies the delimited blocks that AsciiDoc provides by default, their purpose and what substitutions are performed on its content.
 
-[cols="1,1m,1,1" options="header"]
+[cols="1,1m,1,1", options="header"]
 |===
 |Name (Style) |Line delimiter |Purpose |Substitutions
 
@@ -1629,7 +1629,7 @@ Here's a simple example of a table with two columns and three rows:
 
 [source]
 ----
-[cols=2]
+[cols="2*"]
 |===
 |Firefox
 |Web Browser
@@ -1642,14 +1642,17 @@ Here's a simple example of a table with two columns and three rows:
 |===
 ----
 
-The first non-blank line determines the number of columns.
-Since we are putting each column on a separate line, we have to be explicit about the number of columns in the +cols+ block attribute.
+The first non-blank line inside the block delimiter (+|===+) determines the number of columns.
+Since we are putting each column title on a separate line, we have to use the +cols+ block attribute to explicitly state that this table has two columns.
+The +*+ is the repeat operator. 
+It means to repeat the column specification for the remainder of columns. 
+In this case, it means to repeat no special formatting (since none is present) across 2 columns.
 
 We can make the first row of the table the header by setting the +header+ option on the table.
 
 [source]
 ----
-[cols=2, options="header"]
+[cols="2*", options="header"]
 |===
 |Name
 |Group
@@ -1664,7 +1667,7 @@ We can make the first row of the table the header by setting the +header+ option
 |===
 ----
 
-We could define the header cells on one line so that the +cols+ attribute is not required.
+Alternatively, we could define the header cells on one line so that the +cols+ attribute is not required.
 
 [source]
 ----
@@ -1704,13 +1707,15 @@ performance, portability.
 ----
 
 You can set the relative widths of each column using _column specifiers_{mdash}a comma-separated list of relative values defined in the +cols+ block attribute.
-The number of entries in the list determines the number of columns:
+The number of entries in the list determines the number of columns.
 
 [source]
 ----
 [cols="2,3,5", options="header"]
 |===
-|Name |Group |Description
+|Name 
+|Group 
+|Description
 
 |Firefox
 |Web Browser
@@ -1732,7 +1737,9 @@ If you want to include blocks or lists inside the contents of a column, you can 
 ----
 [cols="2,3,5a", options="header"]
 |===
-|Name |Group |Description
+|Name 
+|Group 
+|Description
 
 |Firefox
 |Web Browser


### PR DESCRIPTION
- added table example with column titles on single line to quick ref
- added table example with cols and repeat operator to quick ref
- clarified column relative width in quick ref
- added repeat operator definition to writers guide
- updated cols value syntax in quick and writers ref tables

Also related to issue [386](https://github.com/asciidoctor/asciidoctor/issues/386).
