### PR TITLE
Fix up linkcss and copycss semantics

### DIFF
--- a/docs/render-documents.adoc
+++ b/docs/render-documents.adoc
@@ -127,9 +127,9 @@ It comes bundled with a fresh, modern stylesheet, named +asciidoctor.css+.
 When you generate a document with the +html5+ backend, the +asciidoctor.css+ stylesheet is applied and linked automatically by default.
 However, +asciidoctor.css+ is not automatically available to the generated HTML document; you have two choices:
 
-. If you prefer to copy +asciidoctor.css+ to the output location and link to it from the generated document, set the +copycss+ attribute:
+. If you prefer to copy +asciidoctor.css+ to the output location and link to it from the generated document, set the +linkcss+ attribute:
 
- $> asciidoctor -a copycss sample.adoc
+ $> asciidoctor -a linkcss sample.adoc
 
 . If you prefer to embed the stylesheet into the document, unset the +linkcss+ attribute:
 
@@ -137,7 +137,7 @@ However, +asciidoctor.css+ is not automatically available to the generated HTML 
 
 Just browse to +sample.html+ in your browser and checkout the result!
 
-TIP: +linkcss!+ (which implies "embed css") embeds any stylesheet, not just +asciidoctor.css+.
+TIP: +linkcss!+ (which implies "embed css" or +copycss+) embeds any stylesheet, not just +asciidoctor.css+.
 
 IMPORTANT: +linkcss+ is set by default, unlike in AsciiDoc.
 We believe linking to the stylesheet is a better default, certainly a accepted practice on the web.


### PR DESCRIPTION
The linkcss attribute copies (and links) the stylesheet, while the copycss attribute embeds the stylesheet. This commit fixes reversed meaning in the documentation.
