### PR TITLE
Fix link typo in render-documents.adoc

### DIFF
--- a/docs/render-documents.adoc
+++ b/docs/render-documents.adoc
@@ -9,7 +9,7 @@ Dan Allen; Sarah White
 :includedir: _includes
 :docref: link:/docs
 :install-ref: {docref}/install-toolchain
-:fopdf-ref: https://github.com/mojavelinux/asciidoctor-fopd
+:fopdf-ref: https://github.com/mojavelinux/asciidoctor-fopdf
 :fopdf-doc-ref: https://github.com/mojavelinux/asciidoctor-fopdf/blob/master/README.adoc
 :docbook5-ref: http://www.docbook.org/tdg5/en/html/ch01.html#introduction-whats-new
 :yelp: http://live.gnome.org/Yelp


### PR DESCRIPTION
Typo in link to asciidoctor-fopdf.
