### PR TITLE
Updated details of default safe mode when using the API.

### DIFF
--- a/docs/_includes/secure-api.adoc
+++ b/docs/_includes/secure-api.adoc
@@ -4,7 +4,7 @@ Included in:
 - user-manual: Running Asciidoctor Securely: Set the safe mode in the API
 ////
 
-The default safe level in the API is +SERVER+.
+The default safe level in the API is +SECURE+.
 
 In the API, you can set the safe mode using a string, symbol or integer value.
 The value must be set in the document constructor using the +:safe+ option.

--- a/docs/_includes/secure.adoc
+++ b/docs/_includes/secure.adoc
@@ -34,7 +34,6 @@ This level trims +docfile+ to its relative path and prevents the document from:
 +
 It allows +icons+ and +linkcss+.
 +
-*This is the default safe mode for the API.*
 Its integer value is +10+.
 
 +SECURE+::
@@ -54,7 +53,7 @@ Additionally, it:
 --
 +
 Asciidoctor and trusted extensions may still be allowed to embed trusted content into the document.
-Its integer value is +20+.
+*This is the default safe mode for the API.* Its integer value is +20+.
 
 ////
 |===


### PR DESCRIPTION
My first contribution and it's a tiny tweak to the docs. :)

Everything I've been able to find seems to suggest that the default safe mode when using the API is SECURE and not SERVER, so I've updated the user manual to reflect this.

I'm guessing this is the same when using AsciidoctorJ as well.
