### PR TITLE
Remove part with no section.

### DIFF
--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -1910,11 +1910,6 @@ NOTE: Section pending
 
 NOTE: Section pending
 
-= Conclusion
-
-[partintro]
-NOTE: Section pending
-
 = Resources
 
 [partintro]


### PR DESCRIPTION
asciidoctor from git complains about the user manual as follows:

  asciidoctor: ERROR: user-manual.adoc: line 1918: invalid part, must have at least one section (e.g., chapter, appendix, etc.)

Omit the part titled "Conclusion", as it is essentially empty and prevents
the document from being processed.  It can always be re-added later if
needed.
