### PR TITLE
fix the explanation of file name of docinfo1 attribute in user manual.

### DIFF
--- a/docs/_includes/docinfo-attr.adoc
+++ b/docs/_includes/docinfo-attr.adoc
@@ -29,8 +29,8 @@ The attributes and the corresponding file names are listed in the table below.
 
 |docinfo1
 |Add content to all documents in the same directory
-|+<docname>.html+ 
-|+<docname>.xml+
+|+docinfo.html+ 
+|+docinfo.xml+
 
 |docinfo2
 |Add content from either docinfo file


### PR DESCRIPTION
At [the section 7.2](http://asciidoctor.org/docs/user-manual/#docinfo-attributes-and-file-names) in [Asciidoctor User Manual](http://asciidoctor.org/docs/user-manual/), the table explains that I save a docinfo file as `<docname>.html` when using the attribute "docinfo1".
But, at proceeding texts, the item 2 of list explains "save the docinfo file as docinfo.html".

The table's text is a error.
