### PR TITLE
Only lines from AsciiDoc files are preprocessed.

### DIFF
--- a/docs/_includes/include-directive.adoc
+++ b/docs/_includes/include-directive.adoc
@@ -8,6 +8,10 @@ The +include+ directive allows you to insert the content of a file directly into
 The include directive resolves files relative to the current document instead of the root document.
 This applies to include directives used inside a file which itself has been included.
 
+Note that only AsciiDoc files are preprocessed when included.
+Therefore, +include+ or other preprocessor directives in non-AsciiDoc files will be treated simply as part of the text.
+Asciidoctor recognizes those files with the +.asciidoc+, +.adoc+, +.ad+, +.asc+, or +.txt+ extensions as AsciiDoc files.
+
 .Document parts
 [source]
 ----


### PR DESCRIPTION
Note that only AsciiDoc files are preprocessed and that things that look like preprocessor directives will be ignored in other files.

I left each sentence as a separate line since that seems to be what the rest of the file does.  Let me know if you'd like any changes.

Fixes #180.
