### PR TITLE
Remove trailing whitespace from docs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+end_of_line = lf
+
+[*.adoc]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ First, install http://rvm.io[RVM]. Trust me on this.
 
 Next, setup an RVM gemset for working with the Asciidoctor site:
 
- $ rvm use 2.3.3@asciidoctor.org --create 
+ $ rvm use 2.3.3@asciidoctor.org --create
 
 At this point, you could install Awestruct directly, but since the site build has some additional dependencies, it's best to let bundler handle the installation. Bundler will also ensure that you are using the correct versions of each gem when you run Awestruct.
 

--- a/Rakefile
+++ b/Rakefile
@@ -125,6 +125,9 @@ desc 'Generate site from Travis CI and, if not a pull request, publish site to p
 task :travis do
   # force use of bundle exec in Travis environment
   $use_bundle_exec = true
+
+  reject_trailing_whitespace
+
   # if this is a pull request, do a simple build of the site and stop
   if ENV['TRAVIS_PULL_REQUEST'].to_s.to_i > 0
     msg 'Pull request detected. Executing build only.'
@@ -362,6 +365,17 @@ def set_pub_dates(branch)
 
     if do_commit
       repo.push('origin', branch)
+    end
+  end
+end
+
+def reject_trailing_whitespace
+  Dir['**/*.adoc'].each do |file|
+    # Don't check external gems.
+    next if file =~ /^vendor\//
+    IO.readlines(file).each_with_index do |ln, i|
+      ln.chomp!
+      raise "#{file} contains trailing whitespace on line #{i + 1}" if ln =~ /\s+\Z/
     end
   end
 end

--- a/docs/_includes/asciidoctor-ant.adoc
+++ b/docs/_includes/asciidoctor-ant.adoc
@@ -10,8 +10,8 @@ Usage is:
 <project xmlns:asciidoctor="antlib:org.asciidoctor.ant">
 ...
     <target name="doc">
-        <taskdef uri="antlib:org.asciidoctor.ant" 
-           resource="org/asciidoctor/ant/antlib.xml" 
+        <taskdef uri="antlib:org.asciidoctor.ant"
+           resource="org/asciidoctor/ant/antlib.xml"
            classpath="lib/asciidoctor-ant.jar"/>
         <asciidoctor:convert sourceDirectory="src/asciidoc" outputDirectory="target"/>
     </target>

--- a/docs/_includes/attr-use.adoc
+++ b/docs/_includes/attr-use.adoc
@@ -16,7 +16,7 @@ For example:
 Many attributes can be assigned a value at the same time:
 
  :leveloffset: 3
- 
+
 The value may be empty, a string (of characters) or a number.
 A string value may include references to other attributes.
 
@@ -38,7 +38,7 @@ An [.term]_attribute reference_ is an inline element composed of the name of the
 For example:
 
  The value of leveloffset is {leveloffset}.
- 
+
 The attribute reference is replaced by the attribute's value when Asciidoctor processes the document.
 Referencing an attribute that is not set is considered an error and is handled specially by the processor.
 

--- a/docs/_includes/attrs-builtin.adoc
+++ b/docs/_includes/attrs-builtin.adoc
@@ -60,7 +60,7 @@ See <<migrating-from-asciidoc-python>> if you are updating an older document.
 |<<migrating-from-asciidoc-python>>
 
 |experimental
-|Enable experimental extensions. 
+|Enable experimental extensions.
 The features behind this attribute are subject to change and may even be removed in a future version.
 Currently enables the UI macros (button, menu and kbd).
 |_not set_
@@ -172,7 +172,7 @@ Unsetting it will remove the label and time from the footer.
 |<<user-preface>>
 
 |table-caption
-|Text of the label that is automatically prefixed to table titles. 
+|Text of the label that is automatically prefixed to table titles.
 To turn off table caption labels and numbers, add the `table-caption` attribute to the document header with an empty value.
 |Table
 |_any_
@@ -424,18 +424,18 @@ _Since this is a reserved attribute that has special behavior, you should avoid 
 |<<subtitle-partitioning>>
 
 |toc
-|Switches the table of contents on, and defines its location.	
+|Switches the table of contents on, and defines its location.
 |_not set_
 |auto, left, right, macro or preamble
 |{y}
-|<<user-toc>>	
+|<<user-toc>>
 
 |toclevels
 |Maximum section level to display.
 |2
 |1{endash}5
 |{y}
-|<<user-toc>>	
+|<<user-toc>>
 
 // NOTE toc-placement moved to deprecated table in migration guide
 //|toc-placement
@@ -929,6 +929,6 @@ Since attributes can reference other attributes, it would be possible to create 
 |====
 
 ^[1]^ The default value isn't necessarily the value you will get by entering `\{name}`.
-It may be the fallback value which Asciidoctor uses if the attribute is not defined. 
+It may be the fallback value which Asciidoctor uses if the attribute is not defined.
 The effect is the same either way.
 // end::table[]

--- a/docs/_includes/attrs-env.adoc
+++ b/docs/_includes/attrs-env.adoc
@@ -18,11 +18,11 @@ It's recommended that you treat these attributes as read only.
 |===
 |Attribute |Description |Example Value
 
-|asciidoctor 
+|asciidoctor
 |Set if the current processor is Asciidoctor.
 |{asciidoctor}
 
-|asciidoctor-version 
+|asciidoctor-version
 |Asciidoctor version.
 |{asciidoctor-version}
 
@@ -43,11 +43,11 @@ For example, if the backend is `docbook5`, the basebackend is `docbook`.
 |Last modified date and time of the source document.^[1,2]^
 |2015-01-04 19:26:06 GMT+0000
 
-|docdir 
+|docdir
 |Full path of the directory that contains the source document.
 |/home/user/docs
 
-|docfile 
+|docfile
 |Full path of the source document.
 |/home/user/docs/userguide.adoc
 
@@ -56,7 +56,7 @@ For example, if the backend is `docbook5`, the basebackend is `docbook`.
 |userguide
 
 |doctime
-|Last modified time of the source document.^[1,2]^ 
+|Last modified time of the source document.^[1,2]^
 |19:26:06 GMT+0000
 
 |doctype
@@ -67,7 +67,7 @@ For example, if the backend is `docbook5`, the basebackend is `docbook`.
 |Set if content is being converted to an embeddable document (body only).
 |
 
-|filetype 
+|filetype
 |File extension of the output file name (without leading period).
 |html
 
@@ -75,19 +75,19 @@ For example, if the backend is `docbook5`, the basebackend is `docbook`.
 |Syntax used when generating the HTML output (html or xhtml).
 |html
 
-|localdate 
+|localdate
 |Date when converted.^[2]^
 |2016-02-17
 
 |localdatetime
-|Date and time when converted.^[2]^ 
+|Date and time when converted.^[2]^
 |2016-02-17 19:31:05 GMT+0000
 
 |localtime
 |Time when converted.^[2]^
 |19:31:05 GMT+0000
 
-|outdir 
+|outdir
 |Full path of the output directory.
 |/home/user/docs/dist
 

--- a/docs/_includes/command-line-usage.adoc
+++ b/docs/_includes/command-line-usage.adoc
@@ -3,7 +3,7 @@ Command line usage quick start for Asciidoctor
 This file is included in the install-toolchain and user-manual documents
 ////
 
-Asciidoctor's command line interface (CLI) is a drop-in replacement for the `asciidoc.py` command from the Python implementation. 
+Asciidoctor's command line interface (CLI) is a drop-in replacement for the `asciidoc.py` command from the Python implementation.
 
 If the Asciidoctor gem installed successfully, the `asciidoctor` command line interface (CLI) will be available on your PATH.
 To confirm that Asciidoctor is available, execute:

--- a/docs/_includes/counter.adoc
+++ b/docs/_includes/counter.adoc
@@ -24,7 +24,7 @@ To create a sequence starting at 1, use the simple form `+{counter:name}+` as sh
 
 [source,asciidoc]
 The salad calls for {counter:seq1}) apples, {counter:seq1}) oranges and {counter:seq1}) pears.
- 
+
 Here's the resulting output:
 
 ====

--- a/docs/_includes/docinfo.adoc
+++ b/docs/_includes/docinfo.adoc
@@ -146,7 +146,7 @@ For example:
 :docinfo: shared,private-footer
 ----
 
-This docinfo configuration will apply the shared docinfo head and footer files, if they exist, as well as the private footer file, if it exists. 
+This docinfo configuration will apply the shared docinfo head and footer files, if they exist, as well as the private footer file, if it exists.
 
 // NOTE migrate this NOTE to the migration guide once 1.6 is released
 [NOTE]
@@ -179,7 +179,7 @@ If other AsciiDoc files are added to the same folder, and `docinfo` is set to `s
 
 === Locating docinfo files
 
-By default, docinfo files are searched for in the same folder as the document file. 
+By default, docinfo files are searched for in the same folder as the document file.
 If you want to keep them anywhere else, set the `docinfodir` attribute to their location:
 
 [source,asciidoc]

--- a/docs/_includes/ex-table.adoc
+++ b/docs/_includes/ex-table.adoc
@@ -5,7 +5,7 @@ Examples for table sections
 // tag::base-co[]
 |=== <1>
 <2>
-| Cell in column 1, row 1 | Cell in column 2, row 1  <3> 
+| Cell in column 1, row 1 | Cell in column 2, row 1  <3>
 <4>
 | Cell in column 1, row 2 | Cell in column 2, row 2
 
@@ -44,8 +44,8 @@ Examples for table sections
 |Cell in column 2, row 1
 |Cell in column 3, row 1
 
-|Cell in column 1, row 2 
-|Cell in column 2, row 2 
+|Cell in column 1, row 2
+|Cell in column 2, row 2
 |Cell in column 3, row 2
 |===
 // end::base[]
@@ -106,10 +106,10 @@ Examples for table sections
 // tag::same-indv[]
 [cols="3*"]
 |===
-|Cell in column 1, row 1 |Cell in column 2, row 1 
+|Cell in column 1, row 1 |Cell in column 2, row 1
 |Cell in column 3, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2 |Cell in column 3, row 2
 |===
 // end::same-indv[]
@@ -119,7 +119,7 @@ Examples for table sections
 
 |Cell in column 1, row 1 |Cell in column 2, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 
 |===
@@ -132,7 +132,7 @@ Examples for table sections
 |Cell in column 1, row 1
 |Cell in column 2, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 
 |===
@@ -173,7 +173,7 @@ Examples for table sections
 |Cell in column 1, row 1
 |Cell in column 2, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 |===
 // end::opt-h[]
@@ -185,7 +185,7 @@ Examples for table sections
 |Cell in column 1, row 1
 |Cell in column 2, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 |===
 // end::impl-h[]
@@ -198,7 +198,7 @@ Examples for table sections
 |Cell in column 1, row 1
 |Cell in column 2, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 
 |Footer in column 1, row 3
@@ -214,7 +214,7 @@ Examples for table sections
 |Cell in column 2, row 1
 |Cell in column 3, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 |Cell in column 3, row 2
 |===
@@ -229,7 +229,7 @@ Examples for table sections
 |Cell in column 2, row 1
 |Cell in column 3, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 |Cell in column 3, row 2
 |===
@@ -244,7 +244,7 @@ Examples for table sections
 |Cell in column 2, row 1
 |Cell in column 3, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 |Cell in column 3, row 2
 |===
@@ -253,13 +253,13 @@ Examples for table sections
 // tag::b-col-h-co[]
 [cols="2*", options="header"] <1>
 |===
-|Name of Column 1 
-|Name of Column 2 
+|Name of Column 1
+|Name of Column 2
 
 |Cell in column 1, row 1
 |Cell in column 2, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 |===
 // end::b-col-h-co[]
@@ -267,13 +267,13 @@ Examples for table sections
 // tag::b-col-h[]
 [cols="2*", options="header"]
 |===
-|Name of Column 1 
-|Name of Column 2 
+|Name of Column 1
+|Name of Column 2
 
 |Cell in column 1, row 1
 |Cell in column 2, row 1
 
-|Cell in column 1, row 2 
+|Cell in column 1, row 2
 |Cell in column 2, row 2
 |===
 // end::b-col-h[]

--- a/docs/_includes/html-ruby-api.adoc
+++ b/docs/_includes/html-ruby-api.adoc
@@ -4,7 +4,7 @@ HTML output section
 == Using the Ruby API
 
 This document is included in render-documents and the user-manual.
-TODO: expand this section 
+TODO: expand this section
 ////
 
 Asciidoctor also includes a Ruby API that lets you generate an HTML document directly from a Ruby application.

--- a/docs/_includes/image-sizing.adoc
+++ b/docs/_includes/image-sizing.adoc
@@ -102,7 +102,7 @@ DocBook also accepts the `width` attribute if `scaledwidth` is not provided.
 
 |docbook
 |scaledwidth=100mm +
-(or cm, em, in, pc, pt, px) 
+(or cm, em, in, pc, pt, px)
 |scale=80
 |scaledwidth=50%
 |Not possible

--- a/docs/_includes/language-support.adoc
+++ b/docs/_includes/language-support.adoc
@@ -24,7 +24,7 @@ In the interim, you can leverage the DocBook toolchain to get right-to-left supp
 === Customizing built-in labels
 
 If you're creating DocBook output, you can rely on the DocBook toolchain to translate (most) built-in labels.
-To activate this feature, simply set the `lang` attribute to a valid country code (which defaults to `en` for English). 
+To activate this feature, simply set the `lang` attribute to a valid country code (which defaults to `en` for English).
 For example:
 
 ----
@@ -68,7 +68,7 @@ When creating HTML or PDF (via Asciidoctor PDF), you must translate each built-i
 |Last updated
 
 |listing-caption
-|The label for listing blocks. 
+|The label for listing blocks.
 By default, listing blocks do not have captions.
 If you specify `listing-caption`, then you also turn on captions for listing blocks.
 |_not set_
@@ -86,7 +86,7 @@ If you specify `listing-caption`, then you also turn on captions for listing blo
 |_not set_
 
 |table-caption
-|Automatically prefixed to table titles. 
+|Automatically prefixed to table titles.
 |Table
 
 |tip-caption

--- a/docs/_includes/manpage.adoc
+++ b/docs/_includes/manpage.adoc
@@ -23,7 +23,7 @@ Note that the manpage converter sets the output file name to `progname.1`, where
 To see the man page in HTML instead, run:
 
  $ asciidoctor -d manpage source.adoc
- 
+
 Here is a man page for the command `eve` written in AsciiDoc:
 
 [source,asciidoc]

--- a/docs/_includes/messages.adoc
+++ b/docs/_includes/messages.adoc
@@ -249,14 +249,14 @@ If it is a URI and `-a allow-uri-read` is set, does it exist?
 
 |WARNING
 |<docname> multiple ids detected in style attribute
-|Multiple IDs cannot be specified in the block style (e.g., `[#cat#dog]`). 
+|Multiple IDs cannot be specified in the block style (e.g., `[#cat#dog]`).
 // But [#wibble,id="wobble"] does not generate an error
 |<<id>>
 
 |WARNING
 |<docname> no callouts refer to list item <x>
-|The callout is missing or not recognized. 
-In source listings, is the callout the last thing on the line? 
+|The callout is missing or not recognized.
+In source listings, is the callout the last thing on the line?
 |<<callouts>>
 
 |WARNING
@@ -266,7 +266,7 @@ In source listings, is the callout the last thing on the line?
 |====
 
 ////
-API only 
+API only
 
 |ERROR
 |IOError, %(target directory does not exist: #{to_dir})

--- a/docs/_includes/multi-special-ex.adoc
+++ b/docs/_includes/multi-special-ex.adoc
@@ -31,7 +31,7 @@ I would like to thank the Big Bang and String Theory.
 [dedication]
 = Dedication
 
-For S.S.T.-- 
+For S.S.T.--
 
 thank you for the plague of archetypes.
 // end::dedicate[]

--- a/docs/_includes/project-author.adoc
+++ b/docs/_includes/project-author.adoc
@@ -6,7 +6,7 @@ Included in:
 
 *Asciidoctor* was written by {mojavelinux}[Dan Allen], {erebor}[Ryan Waldron], {lightguard}[Jason Porter], {nickh}[Nick Hengeveld] and {contributors}[other contributors].
 
-The initial code from which Asciidoctor emerged was written by {nickh}[Nick Hengeveld] to process the git man pages for the {gitscm-next}[Git project site]. 
+The initial code from which Asciidoctor emerged was written by {nickh}[Nick Hengeveld] to process the git man pages for the {gitscm-next}[Git project site].
 Refer to the commit history of {seed-contribution}[asciidoc.rb] to view the initial contributions.
 
 *AsciiDoc* was written by Stuart Rackham and has received contributions from many other individuals.

--- a/docs/_includes/project-lic.adoc
+++ b/docs/_includes/project-lic.adoc
@@ -4,7 +4,7 @@ Included in:
 - user-manual: Copyright and License
 ////
 
-Copyright (C) 2012-2014 Dan Allen and Ryan Waldron. 
+Copyright (C) 2012-2014 Dan Allen and Ryan Waldron.
 Free use of this software is granted under the terms of the MIT License.
 
 See the {license}[LICENSE] file for details.

--- a/docs/_includes/ruby-api-options.adoc
+++ b/docs/_includes/ruby-api-options.adoc
@@ -89,7 +89,7 @@ NOTE: The default value for this option is opposite of the default value for the
 _(Implicitly enabled)._
 
 |:parse
-|If true, the source is parsed eagerly (i.e., as soon as the source is passed to the `load` or `load_file` API). 
+|If true, the source is parsed eagerly (i.e., as soon as the source is passed to the `load` or `load_file` API).
 If false, parsing is deferred until the `parse` method is explicitly invoked.
 |true
 |_boolean_
@@ -109,7 +109,7 @@ If false, parsing is deferred until the `parse` method is explicitly invoked.
 |_n/a_
 
 |:template_cache
-|If true, enables the built-in cache used by the template converter when reading the source of template files. 
+|If true, enables the built-in cache used by the template converter when reading the source of template files.
 Only relevant if the `:template_dirs` option is specified.
 |true
 |_boolean_
@@ -138,7 +138,7 @@ This name is also used to build the full path to the custom converter templates.
 |`-E`, `--template-engine`
 
 |:template_engine_options
-|Low-level options passed directly to the template engine. 
+|Low-level options passed directly to the template engine.
 //(You can see an example in the Bespoke.js converter at https://github.com/asciidoctor/asciidoctor-bespoke/blob/v1.0.0.alpha.1/lib/asciidoctor-bespoke/converter.rb#L24-L28).
 |_not set_
 |A nested Hash of options with the template engine name as the top-level key and the option name as the second-level key.

--- a/docs/_includes/secure.adoc
+++ b/docs/_includes/secure.adoc
@@ -61,11 +61,11 @@ Asciidoctor extensions may still embed content into the document depending wheth
 
 |{empty} |Unsafe |Safe |Server |Secure
 
-|URI access 
-|system access 
-|base directory access 
-|docdir 
-|docfile 
+|URI access
+|system access
+|base directory access
+|docdir
+|docfile
 |docinfo
 |backend
 |doctype
@@ -78,7 +78,7 @@ Asciidoctor extensions may still embed content into the document depending wheth
 
 |===
 
-TIP: GitHub processes AsciiDoc files using the +SECURE+ level. 
+TIP: GitHub processes AsciiDoc files using the +SECURE+ level.
 ////
 
 You can set Asciidoctor's safe mode level using the CLI or API.

--- a/docs/_includes/subs-symbol-repl.adoc
+++ b/docs/_includes/subs-symbol-repl.adoc
@@ -33,7 +33,7 @@ Included in:
 |\--
 |\&#8212;
 |{empty}--{empty}
-|Only replaced if it is a word, i.e. surrounded by white space, line start, or line end. 
+|Only replaced if it is a word, i.e. surrounded by white space, line start, or line end.
 
 When white space characters are detected on both sides of the em dash, they are replaced by thin spaces (\&#8201;).
 

--- a/docs/_includes/templates-api.adoc
+++ b/docs/_includes/templates-api.adoc
@@ -3,8 +3,8 @@ Provide custom templates using the API
 This file is included in the user-manual document
 ////
 
-Asciidoctor allows you to override the converter methods used to render almost any individual AsciiDoc element. 
-If you provide a directory of {uri-tilt}[Tilt]-compatible templates, named in such a way that Asciidoctor can figure out which template goes with which element, Asciidoctor will use the templates in this directory instead of its built-in templates for any elements for which it finds a matching template. 
+Asciidoctor allows you to override the converter methods used to render almost any individual AsciiDoc element.
+If you provide a directory of {uri-tilt}[Tilt]-compatible templates, named in such a way that Asciidoctor can figure out which template goes with which element, Asciidoctor will use the templates in this directory instead of its built-in templates for any elements for which it finds a matching template.
 It will fallback to its default templates for everything else.
 
 [source,ruby]
@@ -13,12 +13,12 @@ It will fallback to its default templates for everything else.
    :template_dir => 'templates'
 ----
 
-The Document and Section templates should begin with +document.+ and +section.+, respectively. 
-The file extension is used by Tilt to determine which view framework it will use to use to render the template. 
-For instance, if you want to write the template in ERB, you'd name these two templates +document.html.erb+ and +section.html.erb+. 
+The Document and Section templates should begin with +document.+ and +section.+, respectively.
+The file extension is used by Tilt to determine which view framework it will use to use to render the template.
+For instance, if you want to write the template in ERB, you'd name these two templates +document.html.erb+ and +section.html.erb+.
 To use Haml, you'd name them +document.html.haml+ and +section.html.haml+.
 
-Templates for block elements, like a Paragraph or Sidebar, would begin with +block_<style>.+. 
+Templates for block elements, like a Paragraph or Sidebar, would begin with +block_<style>.+.
 For instance, to override the default Paragraph template with an ERB template, put a file named +block_paragraph.html.erb+ in the template directory you pass to the +Document+ constructor using the +:template_dir+ option.
 
 For more usage examples, see the (massive) {tests}[test suite].

--- a/docs/_includes/troubleshoot.adoc
+++ b/docs/_includes/troubleshoot.adoc
@@ -1,5 +1,5 @@
 = Troubleshooting
-:author: Sarah White 
+:author: Sarah White
 :email: <https://github.com/graphitefriction[@graphitefriction]>
 :description: Tips for fixing installation, syntax, processing, and rendering problems when using Asciidoctor.
 :keywords: Asciidoctor, AsciiDoc, syntax, render, process, problem, issue, tips

--- a/docs/_includes/ts-block-render.adoc
+++ b/docs/_includes/ts-block-render.adoc
@@ -11,7 +11,7 @@ When content is not rendered as you expect in the later part of a document, it's
 The most devious culprit is the <<user-manual#open-blocks,open block>>.
 An open block doesn't have any special styling, but its contents have the same restrictions as other delimited blocks, i.e. it can not contain section titles.
 +
-To solve this problem, first look for missing delimiter lines. 
-<<user-manual#text-editor,Syntax highlighting in your text editor>> can help with this. 
-Also look at the rendered output to see if the block styles are extending past where you intended. 
+To solve this problem, first look for missing delimiter lines.
+<<user-manual#text-editor,Syntax highlighting in your text editor>> can help with this.
+Also look at the rendered output to see if the block styles are extending past where you intended.
 When working with open blocks, you may need to add custom styles (such as a red border) to the class selector +.openblock+ so that you can see its boundaries.

--- a/docs/_includes/uri-include.adoc
+++ b/docs/_includes/uri-include.adoc
@@ -19,7 +19,7 @@ include::ex-include.adoc[tags=uri]
 ----
 ====
 
-IMPORTANT: Including content from sources outside your control carries certain risks, including the potential to introduce malicious behavior into your documentation. 
+IMPORTANT: Including content from sources outside your control carries certain risks, including the potential to introduce malicious behavior into your documentation.
 
 Because `allow-uri-read` is a potentially dangerous feature, it will only work if safe mode is set to `SERVER` or less. `SECURE` or higher prevents this feature from running altogether.
 

--- a/docs/asciidoc-asciidoctor-diffs.adoc
+++ b/docs/asciidoc-asciidoctor-diffs.adoc
@@ -19,7 +19,7 @@ endif::[]
 :buildref: http://github.com/asciidoctor/asciidoctor-stylesheet-factory/blob/master/README.adoc
 :mailinglist: http://discuss.asciidoctor.org
 
-Asciidoctor aims to be compliant with the AsciiDoc syntax, but there are some differences to keep in mind. 
+Asciidoctor aims to be compliant with the AsciiDoc syntax, but there are some differences to keep in mind.
 Many of these differences exist so that Asciidoctor can:
 
 * enforce rules we believe are too lax or ambiguous in AsciiDoc
@@ -191,8 +191,8 @@ NOTE: In general, Asciidoctor handles whitespace much more intelligently
 
 * Asciidoctor includes a modern default stylesheet based on Foundation.
 
-* Asciidoctor links to, rather than embeds, the default stylesheet into the document by default (e.g., +linkcss+). 
-To include the default stylesheet, you can either use the +copycss+ attribute to tell Asciidoctor to copy it to the output directory, or you can embed it into the document using the +linkcss!+ attribute. 
+* Asciidoctor links to, rather than embeds, the default stylesheet into the document by default (e.g., +linkcss+).
+To include the default stylesheet, you can either use the +copycss+ attribute to tell Asciidoctor to copy it to the output directory, or you can embed it into the document using the +linkcss!+ attribute.
 You can also provide your own stylesheet using the +stylesheet+ attribute.
 
 == Processor

--- a/docs/asciidoclet.adoc
+++ b/docs/asciidoclet.adoc
@@ -28,8 +28,8 @@ endif::[]
 
 == Introduction
 
-Traditionally, Javadocs have mixed minor markup with HTML which, if you're writing for HTML Javadoc output, becomes unreadable and hard to write over time. 
-This is where lightweight markup languages like {asciidoc-ref}[AsciiDoc] thrive. 
+Traditionally, Javadocs have mixed minor markup with HTML which, if you're writing for HTML Javadoc output, becomes unreadable and hard to write over time.
+This is where lightweight markup languages like {asciidoc-ref}[AsciiDoc] thrive.
 AsciiDoc straddles the line between readable markup and beautifully rendered content.
 
 Asciidoclet incorporates an AsciiDoc renderer (Asciidoctor via the {asciidoctor-java-ref}[Asciidoctor Java integration] library) into a simple Doclet that enables AsciiDoc formatting within Javadoc comments and tags.
@@ -144,7 +144,7 @@ configurations {
 dependencies {
     asciidoclet 'org.asciidoctor:asciidoclet:1.+'
 }
- 
+
 javadoc {
     options.docletpath = configurations.asciidoclet.files.asType(List)
     options.doclet = 'org.asciidoctor.Asciidoclet'

--- a/docs/asciidoctor-maven-plugin.adoc
+++ b/docs/asciidoctor-maven-plugin.adoc
@@ -66,7 +66,7 @@ As this is a typical Maven plugin, there isn't much to do to use it, simply add 
 <1> This plugin tracks the version of Asciidoctor, so you can use which ever version of Asciidoctor you prefer.
 
 Upgrading the plugin to the next version is simple.
-Just update the version in your Maven POM. 
+Just update the version in your Maven POM.
 All the necessary dependencies are retrieved from Maven Central the next time you run Maven.
 
 == Usage
@@ -114,7 +114,7 @@ extensions:: a `List<String>` of non-standard extensions to render; currently `.
 
 === Built-in attributes
 
-There are various attributes Asciidoctor recognizes. 
+There are various attributes Asciidoctor recognizes.
 Below is a list of them and what they do::
 
 title:: An override for the title of the document.
@@ -147,7 +147,7 @@ These settings can be changed in the `<configuration>` section of the plugin sec
 
 === Multiple outputs for the same file
 
-Maven has the ability to execute a Mojo multiple times. 
+Maven has the ability to execute a Mojo multiple times.
 Instead of reinventing the wheel inside the Mojo, we'll push this off to Maven to handle the multiple executions.
 An example of this setup is below:
 
@@ -193,7 +193,7 @@ An example of this setup is below:
     </configuration>
 </plugin>
 ----
-<1> `imagesDir` should be relative to the source directory. 
+<1> `imagesDir` should be relative to the source directory.
 It defaults to `images` but in this example the images used in the docs are also used elsewhere in the project.
 
 Any configuration specified outside the executions section is inherited by each execution.

--- a/docs/asciidoctorj.adoc
+++ b/docs/asciidoctorj.adoc
@@ -1065,7 +1065,7 @@ String content = asciidoctor.convertFile(new File(
 
 === DocinfoProcessor
 
-This extension inserts custom content on header or footer of the document. 
+This extension inserts custom content on header or footer of the document.
 For example can be used for adding `meta` tags on `<head>` tags.
 
 [source]
@@ -1695,8 +1695,8 @@ Follow the steps below:
     </dependencies>
 </module>
 ----
-. Copy the jar files into the same folder as the _module.xml_ file. 
-. Make sure the version numbers of the jar files agree with what's in the current set. 
+. Copy the jar files into the same folder as the _module.xml_ file.
+. Make sure the version numbers of the jar files agree with what's in the current set.
 Restart WildFly for the new module to take effect.
 
 . Add a dependency on your Java archive to this WildFly module using one of the following options:

--- a/docs/convert-asciidoc-to-pdf.adoc
+++ b/docs/convert-asciidoc-to-pdf.adoc
@@ -92,7 +92,7 @@ You can get {project-name} by installing the published gem.
 You can install the published gem using the following command:
 
  $ gem install --pre asciidoctor-pdf
- 
+
 If you want to syntax highlight source listings, you'll also want to install CodeRay or Pygments.
 To be safe, go ahead and install both gems:
 

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -9,7 +9,7 @@ Tips for fixing installation, syntax, processing, and rendering problems when us
 :idprefix:
 :idseparator: -
 :language: asciidoc
-:table-caption!: 
+:table-caption!:
 :example-caption!:
 :figure-caption!:
 // :imagesdir: ../images
@@ -19,7 +19,7 @@ Tips for fixing installation, syntax, processing, and rendering problems when us
 
 [qanda]
 Does Asciidoctor only encode in US-ASCII?::
-No. 
+No.
 Asciidoctor encodes in UTF-8 and has full Unicode support.
 
 How do I enable syntax highlighting in the deck.js backend?::
@@ -64,7 +64,7 @@ What is the http://en.wikipedia.org/wiki/Internet_media_type[internet mime type]
 --
 The first idea that emerged from the http://discuss.asciidoctor.org/Mimetype-for-Asciidoc-td211.html[Mimetype for AsciiDoc] discussion on the Asciidoctor mailinglist was:
 
- text/x-asciidoc 
+ text/x-asciidoc
 
 Recently, the internet media type `text/markdown` was registered for Markdown, so another option to consider is:
 

--- a/docs/hack-asciidoctor-maven-plugin.adoc
+++ b/docs/hack-asciidoctor-maven-plugin.adoc
@@ -18,13 +18,13 @@ For help running this plugin, review the {maven-guide-ref}[How do I install and 
 
 == Hacking
 
-Developer setup for hacking on this project isn't difficult. 
+Developer setup for hacking on this project isn't difficult.
 The requirements are:
 
 * Java
 * Maven 3
 
-All the other dependencies will be brought in by Maven. 
+All the other dependencies will be brought in by Maven.
 You should be able to use IntelliJ, Eclipse, or Netbeans without any issue for hacking on the project.
 
 == Building
@@ -35,13 +35,13 @@ Standard Maven build:
 
 == Testing
 
-{spock-ref}[Spock] is used for testing the calling of the Mojo. 
-This will be downloaded by Maven. 
+{spock-ref}[Spock] is used for testing the calling of the Mojo.
+This will be downloaded by Maven.
 Tests are run simply by:
 
  $ mvn clean test
 
-Or any of the other goals which run tests. 
+Or any of the other goals which run tests.
 If I can figure out a good way to setup a Ruby testing environment I'll do that as well, but none exists at this time.
 
 == Resources

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -95,7 +95,7 @@ link:convert-asciidoc-to-epub/[Convert AsciiDoc to EPUB3 with Asciidoctor]::
   Asciidoctor EPUB3 is a native EPUB3 renderer for AsciiDoc. Learn how to install Asciidoctor EPUB3 and use it to convert your AsciiDoc documents directly to EPUB3 and Amazon's KF8/Mobi format for Kindle.
 
 http://www.noteshare.io/section/asciidoctor-latex-manual-intro[Convert AsciiDoc to LaTeX with Asciidoctor]::
-  An extension to Asciidoctor that (a) adds LaTeX-like features to Asciidoctor's HTML backend, (b) converts AsciiDoc documents to LaTeX and (c) converts LaTeX to AsciiDoc documents. 
+  An extension to Asciidoctor that (a) adds LaTeX-like features to Asciidoctor's HTML backend, (b) converts AsciiDoc documents to LaTeX and (c) converts LaTeX to AsciiDoc documents.
 
 == Integrations and Plugins
 

--- a/docs/install-and-use-asciidoctorjs.adoc
+++ b/docs/install-and-use-asciidoctorjs.adoc
@@ -25,7 +25,7 @@ With asciidoctor.js, the {asciidoc}[AsciiDoc] syntax can be used in the browser!
 
 == Introduction
 
-The {asciidoctorjs-git}[asciidoctor.js project] is a direct port of Asciidoctor from Ruby to JavaScript using the {opal}[Opal] Ruby-to-JavaScript cross compiler. 
+The {asciidoctorjs-git}[asciidoctor.js project] is a direct port of Asciidoctor from Ruby to JavaScript using the {opal}[Opal] Ruby-to-JavaScript cross compiler.
 It consists of a Rake build script that executes the Opal compiler on the Asciidoctor source code to produce the asciidoctor.js script.
 
 Opal parses the Ruby code and any required libraries, then rewrites the code into JavaScript under the Opal namespace.

--- a/docs/install-and-use-deckjs-backend.adoc
+++ b/docs/install-and-use-deckjs-backend.adoc
@@ -38,7 +38,7 @@ The Asciidoctor Deck.js backend requires the following Ruby gems:
 * haml
 
 To determine what gems are installed on your system, open a terminal window and type:
- 
+
  $ gem list --local
 
 A list of installed gems will be returned.
@@ -202,7 +202,7 @@ Block two
 
 The `step` option reveals each paragraph, bullet, etc. separately each time you click the _Next_ arrow.
 
-WARNING: The original AsciiDoc `deckjs` backend for the AsciiDoc processor used the option `incremental` instead of `step`. 
+WARNING: The original AsciiDoc `deckjs` backend for the AsciiDoc processor used the option `incremental` instead of `step`.
 We've changed it to `step` in order to save you some typing.
 
 .Split
@@ -234,7 +234,7 @@ To render your presentation as HTML5, execute the command:
  $ asciidoctor -T ../asciidoctor-deck.js/templates/haml presentation.adoc
 
 . The command `-T` (`+--template-dir+`) tells the Asciidoctor processor to override the built-in converter.
-. Directly after `-T` is the path to where you saved or cloned the asciidoctor-deck.js repository containing the templates for the `deckjs` backend (step 1 under the <<backend-and-deck-js-installation,installation section>>).  
+. Directly after `-T` is the path to where you saved or cloned the asciidoctor-deck.js repository containing the templates for the `deckjs` backend (step 1 under the <<backend-and-deck-js-installation,installation section>>).
 
 Further information about rendering documents with Asciidoctor is available in the guide {render-ref}[How do I render a document?]
 

--- a/docs/install-asciidoctor-osx.adoc
+++ b/docs/install-asciidoctor-osx.adoc
@@ -152,7 +152,7 @@ To install MacPorts, you'll need to download the correct OS X Package Installer 
 After installing MacPorts, you'll need to open a *new* shell window and run its `selfupdate` command to upgrade itself and populate the ports collection:
 
  $ sudo port -v selfupdate
- 
+
 Now you are ready to install Asciidoctor by means of:
 
  $ sudo port install asciidoctor
@@ -161,7 +161,7 @@ To verify Asciidoctor is installed correrctly you can execute the `asciidoctor` 
 
  $ asciidoctor -v
 
-If you see the Asciidoctor version information in the terminal, then you're ready to start processing documents! 
+If you see the Asciidoctor version information in the terminal, then you're ready to start processing documents!
 
 .Troubleshooting MacPorts
 [TIP]

--- a/docs/what-is-asciidoc.adoc
+++ b/docs/what-is-asciidoc.adoc
@@ -30,7 +30,7 @@ Even the most brilliant software is useless without good documentation.
 If the users fail, so does the project.
 
 [quote, Nick Coghlan]
-Unless your UI discoverability is *really good*, saying “the feature isn't documented” is the same as saying “the product can't do it.” 
+Unless your UI discoverability is *really good*, saying “the feature isn't documented” is the same as saying “the product can't do it.”
 
 In other words,
 

--- a/docs/what-is-asciidoctor.adoc
+++ b/docs/what-is-asciidoctor.adoc
@@ -27,33 +27,33 @@ Asciidoctor renders AsciiDoc source files and strings to HTML 5, DocBook 4.5 and
 What follows are highlights of its most notable features.
 
 .Built-in and custom templates
-Asciidoctor uses a set of built-in ERB templates to generate HTML 5 and DocBook 4.5 output that is structurally equivalent to what AsciiDoc produces. 
-Any of these templates can be replaced by a custom template written in any template language available in the Ruby ecosystem. 
+Asciidoctor uses a set of built-in ERB templates to generate HTML 5 and DocBook 4.5 output that is structurally equivalent to what AsciiDoc produces.
+Any of these templates can be replaced by a custom template written in any template language available in the Ruby ecosystem.
 Custom template rendering is handled by the https://github.com/rtomayko/tilt[Tilt] template abstraction library (among the most popular gems in the Ruby ecosystem).
 
 .Parser and object model
-Leveraging the Ruby stack isn't the only benefit of Asciidoctor. 
-Unlike the AsciiDoc Python implementation, Asciidoctor parses and renders the source document in discrete steps. 
-This makes rendering the document optional and gives Ruby programs the opportunity to extract, add or replace information in the document by interacting with the document object model Asciidoctor assembles. 
+Leveraging the Ruby stack isn't the only benefit of Asciidoctor.
+Unlike the AsciiDoc Python implementation, Asciidoctor parses and renders the source document in discrete steps.
+This makes rendering the document optional and gives Ruby programs the opportunity to extract, add or replace information in the document by interacting with the document object model Asciidoctor assembles.
 Developers can use the full power of the Ruby programming language to play with the content in the document.
 
 .Performance and security
-No coverage of Asciidoctor would be complete without mention of its 'speed'. 
-Despite not being an original goal of the project, Asciidoctor has proven startlingly fast. 
-It loads, parses and renders documents *50 times as fast* as the Python implementation. 
-That's good news for developer productivity and good news for GitHub or any server-side application that needs to render AsciiDoc markup. 
+No coverage of Asciidoctor would be complete without mention of its 'speed'.
+Despite not being an original goal of the project, Asciidoctor has proven startlingly fast.
+It loads, parses and renders documents *50 times as fast* as the Python implementation.
+That's good news for developer productivity and good news for GitHub or any server-side application that needs to render AsciiDoc markup.
 Asciidoctor also offers several levels of security, further justifying its suitability for server-side deployments.
 
 .Beyond Ruby
-Asciidoctor's usage is not limited to the Ruby community. 
+Asciidoctor's usage is not limited to the Ruby community.
 Thanks to http://jruby.org[JRuby], a port of Ruby to the JVM, Asciidoctor can be used inside Java applications as well.
 Plugins are available for {gh-org}/asciidoctor-maven-plugin[Apache Maven],  {gh-org}/asciidoctor-gradle-plugin[Gradle], and https://github.com/ocpsoft/rewrite/tree/master/transform-markup[Rewrite].
-These plugins are based on the {gh-org}/asciidoctor-java-integration[Java integration library] for Asciidoctor. 
+These plugins are based on the {gh-org}/asciidoctor-java-integration[Java integration library] for Asciidoctor.
 
-Asciidoctor also ships with a command-line interface (cli). 
+Asciidoctor also ships with a command-line interface (cli).
 The Asciidoctor cli, link:/man/asciidoctor/[+asciidoctor+], is a drop-in replacement for the +asciidoc.py+ script from the AsciiDoc Python distribution.
 
 == System requirements
 
-Asciidoctor is published as a RubyGem and currently works with Ruby 1.8.7, Ruby 1.9.3, Ruby 2 (2.0.0 or better), JRuby 1.7, JRuby 9000 and Rubinius 2 (2.0 or better) on Linux, OS X (aka Mac OS X) and Windows. 
+Asciidoctor is published as a RubyGem and currently works with Ruby 1.8.7, Ruby 1.9.3, Ruby 2 (2.0.0 or better), JRuby 1.7, JRuby 9000 and Rubinius 2 (2.0 or better) on Linux, OS X (aka Mac OS X) and Windows.
 We expect it will work with other versions of Ruby as well.

--- a/index.adoc
+++ b/index.adoc
@@ -73,8 +73,8 @@ Asciidoctor.js is used to power the AsciiDoc preview extensions for Chrome, Atom
 
 ifdef::badges[]
 .*Project health*
-image:https://img.shields.io/travis/asciidoctor/asciidoctor/master.svg[Build Status (Travis CI), link=https://travis-ci.org/asciidoctor/asciidoctor] 
-image:https://ci.appveyor.com/api/projects/status/ifplu67oxvgn6ceq/branch/master?svg=true&amp;passingText=green%20bar&amp;failingText=%23fail&amp;pendingText=building%2E%2E%2E[Build Status (AppVeyor), link=https://ci.appveyor.com/project/asciidoctor/asciidoctor] 
+image:https://img.shields.io/travis/asciidoctor/asciidoctor/master.svg[Build Status (Travis CI), link=https://travis-ci.org/asciidoctor/asciidoctor]
+image:https://ci.appveyor.com/api/projects/status/ifplu67oxvgn6ceq/branch/master?svg=true&amp;passingText=green%20bar&amp;failingText=%23fail&amp;pendingText=building%2E%2E%2E[Build Status (AppVeyor), link=https://ci.appveyor.com/project/asciidoctor/asciidoctor]
 //image:https://img.shields.io/coveralls/asciidoctor/asciidoctor/master.svg[Coverage Status, link=https://coveralls.io/r/asciidoctor/asciidoctor]
 image:https://codeclimate.com/github/asciidoctor/asciidoctor/badges/gpa.svg[Code Climate, link="https://codeclimate.com/github/asciidoctor/asciidoctor"]
 image:https://inch-ci.org/github/asciidoctor/asciidoctor.svg?branch=master[Inline docs, link="https://inch-ci.org/github/asciidoctor/asciidoctor"]

--- a/news/asciidoclet-1.5.0-released.adoc
+++ b/news/asciidoclet-1.5.0-released.adoc
@@ -284,7 +284,7 @@ $ gem install asciidoctor-diagram
 . Run Asciidoclet with the following doclet options:
 +
 ----
---require asciidoctor-diagram 
+--require asciidoctor-diagram
 --gem-path ${env.GEM_PATH} <1>
 --attribute data-uri <2>
 ----

--- a/news/asciidoctor-0-1-3-released.adoc
+++ b/news/asciidoctor-0-1-3-released.adoc
@@ -34,7 +34,7 @@ endif::[]
 :doc-variable-ref:  https://github.com/asciidoctor/asciidoctor/wiki/How-to-set-the-background-color-of-a-table-cell
 :backend-git-ref: https://github.com/asciidoctor/asciidoctor-backends
 :gradle-git-ref: https://github.com/asciidoctor/asciidoctor-gradle-plugin
-:ruby-api-ref: link:/rdoc/Asciidoctor.html 
+:ruby-api-ref: link:/rdoc/Asciidoctor.html
 :java-api-ref: https://oss.sonatype.org/service/local/repositories/releases/archive/org/asciidoctor/asciidoctor-java-integration/0.1.2.1/asciidoctor-java-integration-0.1.2.1-javadoc.jar/!/org/asciidoctor/package-summary.html
 
 We're thrilled to announce the release of {gem-ref}[Asciidoctor 0.1.3]. +
@@ -67,7 +67,7 @@ Here's the TL;DR version if you're in a hurry.
 - File encoding and Windows path bugs fixed!
 - Haml/Slim/Jade-inspired syntax for defining the id and role for block content
 - Shorthand syntax to set the table format using the first position of the block delimiter
-- Alternate "air quotes" delimiters for defining block quotations 
+- Alternate "air quotes" delimiters for defining block quotations
 - Support for Markdown blockquotes and headings (to join fenced code blocks)
 - Font-based admonition icons powered by {fontawesome-ref}[Font Awesome^] and CSS-based callout icons
 - Linked section titles as floating anchors or linked title text
@@ -426,11 +426,11 @@ You're untethered!
 Two document attributes are available to control section linking:
 
 +sectanchors+::
-When this attribute is enabled on a document, an anchor (empty link) is added before the section title. 
+When this attribute is enabled on a document, an anchor (empty link) is added before the section title.
 The default Asciidoctor stylesheet renders the anchor as a section entity (+&sect;+) that floats to the left of the section title.
 
 +sectlinks+::
-When this attribute is enabled on a document, the section titles are turned into links. 
+When this attribute is enabled on a document, the section titles are turned into links.
 The default Asciidoctor stylesheet displays linked section titles in the same color as normal section titles.
 
 NOTE: Section title anchors depend on the default Asciidoctor stylesheet to render properly.
@@ -464,7 +464,7 @@ ____
 <p>Words of wisdom.</p>
 </div>
 </blockquote>
-  
+
 <div class="attribution">
 </div>
 
@@ -597,7 +597,7 @@ Now there are even more options for pulling source code snippets into your docum
 
 === Normalizing the block indentation of included source code
 
-Source code snippets from external files are often padded with leading block indent. 
+Source code snippets from external files are often padded with leading block indent.
 This leading block indent is relevant in its original context.
 However, once inside the documentation, this leading block indent is no longer needed.
 
@@ -703,7 +703,7 @@ Consider this source code block:
 [source,java]
 ----
 public class Person {
-  private String name; 
+  private String name;
 
   public String getName() {
     return name;
@@ -767,7 +767,7 @@ To place the TOC under the preamble, assign the new value, +preamble+ to the +to
 The TOC macro requires the +toc+ attribute to be set.
 To disable the built-in TOC, unassign the +toc-placement+ attribute (+toc-placement!+)
 
-==== Updated level 0 section title styles 
+==== Updated level 0 section title styles
 
 Level 0 section titles (only applicable to book doctype) are now organized in their own level within the table of contents (in the HTML backend).
 A CSS class has been added to each outline level (i.e., +<ol>+ element) that cooresponds to the level of the sections it contains (e.g., +sect1level+)
@@ -784,7 +784,7 @@ This change satisfies the requirement that the TOC should "just work" without a 
 
 === Introducing the +inline+ doctype for inline formatting on input text
 
-There may be cases when you only want to apply inline AsciiDoc formatting to input text without wrapping it in a block element. 
+There may be cases when you only want to apply inline AsciiDoc formatting to input text without wrapping it in a block element.
 For example, in the {asciidoclet-ref}[Asciidoclet project] (AsciiDoc in Javadoc), only the inline formatting is needed for the text in Javadoc tags.
 
 The rules for the inline doctype are as follows:
@@ -853,7 +853,7 @@ Resolves issue {issue-ref}/330[330].
 === File encoding errors when using Ruby 1.9 and above is fixed
 
 Asciidoctor was not properly setting the encoding on data read from files when the default system encoding was not UTF-8.
-To correct this issue, any data that comes into Asciidoctor 0.1.3 is force encoded to UTF-8 on Ruby 1.9 and above. 
+To correct this issue, any data that comes into Asciidoctor 0.1.3 is force encoded to UTF-8 on Ruby 1.9 and above.
 Resolves issue {issue-ref}/308[308].
 
 === Additional bug fixes
@@ -871,7 +871,7 @@ Resolves issue {issue-ref}/308[308].
 
 === +doctitle+ attribute
 
-The +doctitle+ attribute can be used anywhere in a document. 
+The +doctitle+ attribute can be used anywhere in a document.
 It's value is identical to the value returned by +Document#doctitle+.
 
 [source,asciidoc]
@@ -882,7 +882,7 @@ It's value is identical to the value returned by +Document#doctitle+.
 The document title is {doctitle}.
 ----
 
-.+doctitle+ output result 
+.+doctitle+ output result
 ....
 The document title is Document Title.
 ....
@@ -910,20 +910,20 @@ Renders:
 <colspec colwidth="15*"/>
 <colspec colwidth="85*"/>
 <tbody valign="top">
-<row> 
-<entry> 
+<row>
+<entry>
 <simpara>first term</simpara>
 </entry>
-<entry> 
+<entry>
 <simpara>definition</simpara>
 <simpara>more detail</simpara>
 </entry>
 </row>
-<row> 
-<entry> 
+<row>
+<entry>
 <simpara>second term</simpara>
 </entry>
-<entry> 
+<entry>
 <simpara>definition</simpara>
 </entry>
 </row>
@@ -990,11 +990,11 @@ It's effectively the same as:
 This is important for being able to assign document attributes in places where attribute entry lines are not normally processed, such as in a table cell.
 
 An example of where this might be used is documented in the {doc-variable-ref}[how to set the background color of a table cell] tip.
- 
+
 === Block title not allowed above document title
 
-Previously, a block title line above a level 0 heading was being processed and passed on to the first content block. 
-AsciiDoc sees the block title as the first line of content and does not create a header as a result. 
+Previously, a block title line above a level 0 heading was being processed and passed on to the first content block.
+AsciiDoc sees the block title as the first line of content and does not create a header as a result.
 Asciidoctor's behavior is now consistent with AsciiDoc.
 
 Example:
@@ -1017,7 +1017,7 @@ irc://irc.freenode.org/#asciidoctor
 
 === Specify any backend with the Asciidoctor CLI
 
-Previously, the Asciidoctor CLI restricted the user from specifying a backend other than +html5+ or +docbook45+. 
+Previously, the Asciidoctor CLI restricted the user from specifying a backend other than +html5+ or +docbook45+.
 Now, any non-empty value can be specified as the backend.
 This is critical when you want to use a {backend-git-ref}[custom backend], such as deck.js or dzslides.
 

--- a/news/asciidoctor-0-1-4-released.adoc
+++ b/news/asciidoctor-0-1-4-released.adoc
@@ -835,9 +835,9 @@ Using the new shorthand notation in Asciidoctor 0.1.4, an id (i.e., anchor) can 
 which produces:
 
 ```html
-<a id="idname"></a><code class="rolename">escaped monospace text</code> 
+<a id="idname"></a><code class="rolename">escaped monospace text</code>
 ```
- 
+
 Keep in mind that text enclosed in backticks is not subject to other inline substitutions, but rather passed through as is.
 
 _Resolves issue {issue-ref}/419[#419]._
@@ -1339,7 +1339,7 @@ By default, Asciidoctor uses an internal cache, though a custom cache can be pas
 
 1. Does the template engine stuff need to be included?
 
-> NOTE: When multiple template directories are specified, the +template_engine+ option no longer applies (mutually exclusive). 
+> NOTE: When multiple template directories are specified, the +template_engine+ option no longer applies (mutually exclusive).
 
 > As it turns out, we don't have to forbid the use of template_engine when using multiple template directories.
 > Asciidoctor will just look for a folder matching the template engine in each template directory (the same logic that's applied when only one template directory is provided).
@@ -1603,7 +1603,7 @@ class TerminalCommandTreeprocessor < Asciidoctor::Extensions::Treeprocessor
       end
     end
     Asciidoctor::Block.new @document, :listing, :content_model => :verbatim, :subs => [],
-        :source => lines * "\n", :attributes => attributes 
+        :source => lines * "\n", :attributes => attributes
   end
 end
 ```
@@ -1637,7 +1637,7 @@ class CustomFooterPostprocessor < Asciidoctor::Extensions::Postprocessor
       output = output.sub(/(<\/(?:article|book)>)/, replacement)
     end
     output
-  end 
+  end
 end
 ```
 
@@ -1736,7 +1736,7 @@ Asciidoctor.render_file('sample-with-gist.ad', :safe => :safe, :in_place => true
 
 ==== Inline macro processor example
 
-Purpose:: 
+Purpose::
   Create an inline macro named +man+ that links to a manpage.
 
 .sample-with-man-link.ad
@@ -1829,7 +1829,7 @@ The following improvements have been made to the AsciiDoc compatibility file, ht
 
 * Added level 5 (+<h6>+) section titles
 * Recognize attributes in link macro when +linkattrs+ is set
-* Removed +linkcss+ attribute 
+* Removed +linkcss+ attribute
 * Fixed detection of fenced code blocks
 * Recognize XML-style callouts
 * Don't prepend +imagesdir+ to image target if it is a URI or absolute path

--- a/news/asciidoctor-java-integration-0-1-2-1-released.adoc
+++ b/news/asciidoctor-java-integration-0-1-2-1-released.adoc
@@ -31,13 +31,13 @@ The following issues have been resolved in version 0.1.2.1:
 
 * Promoted +linkcss+ option to attributes in the fluent API.
   Resolves {issue-ref}/28[#28].
-  
+
 * Promoted +toc+ option to attributes in the fluent API.
   Resolves {issue-ref}/27[#27].
 
 * Added renderFiles method which renders a list of AsciiDoc files.
   Resolves {issue-ref}/23[#23].
-  
+
 * Added create method where you can pass the gem_path variable.
   Resolves {issue-ref}/22[#22], you still need to do some work yourself for adapting to OSGi, but reflection is not required anymore.
 

--- a/news/asciidoctor-java-integration-0-1-3-released.adoc
+++ b/news/asciidoctor-java-integration-0-1-3-released.adoc
@@ -25,16 +25,16 @@ The following issues have been resolved in version 0.1.3:
 
 * Added support for the +parse_header_only+ mode.
   Resolves {issue-ref}/42[#42].
-  
+
 * Promoted +base_dir+ option to attributes in the fluent API.
   Resolves {issue-ref}/43[#43].
 
 * Removed requirement to invoke asMap() on builders.
   Resolves {issue-ref}/45[#45].
-  
+
 * Promoted +numbered+ attribute in the fluent API.
   Resolves {issue-ref}/47[#47].
-  
+
 * Updated asciidoctor dependency to 0.1.3.
   Resolves {issue-ref}/48[#48].
 
@@ -43,7 +43,7 @@ The following issues have been resolved in version 0.1.3:
 
 * Promoted +linkattrs+ attribute in the fluent API.
   Resolves {issue-ref}/51[#51].
-  
+
 * Promoted +experimental+ attribute in the fluent API.
   Resolves {issue-ref}/52[#52].
 

--- a/news/asciidoctor-maven-plugin-0-1-3-released.adoc
+++ b/news/asciidoctor-maven-plugin-0-1-3-released.adoc
@@ -15,7 +15,7 @@ It has taken me a little while longer to get this release out the door than I wo
 I'm proud to release {repo-ref}[Asciidoctor Maven plugin] version 0.1.3!
 Like the other versions before it, it is based on the same version of the {java-int-ref}[Asciidoctor Java integration] project and the {asciidoctor-ref}[Asciidoctor] projects -- 0.1.3.
 
-There's very little new things for the end user in this release as the changes were mostly to use some of the new ease of use things from the Java Integration project. 
+There's very little new things for the end user in this release as the changes were mostly to use some of the new ease of use things from the Java Integration project.
 
 I would like to call out the help of https://github.com/bleathem[Brian Leathem] in this release in helping me go through a few things and pushing me to release it. Also, thank you to all the https://github.com/asciidoctor/asciidoctor-maven-plugin/contributors[contributors] for helping out.
 

--- a/news/enjoy-the-magic-of-asciidoctor-in-java.adoc
+++ b/news/enjoy-the-magic-of-asciidoctor-in-java.adoc
@@ -95,7 +95,7 @@ String render = asciidoctor.renderFile("docs/sample.adoc", options);
 
 See that in previous example we have created a Map, where we have put the options and attributes (creating a Map too) required to render input as docbook and generate an output file.
 
-But +asciidoctor-java-integration+ also provides two builder classes to create these maps in a more readable form. 
+But +asciidoctor-java-integration+ also provides two builder classes to create these maps in a more readable form.
 
 +AttributesBuilder+ is provided for creating a map with required attributes set, and +OptionsBuilder+ can be used for options. Previous example but using these classes looks like:
 

--- a/news/oscon-2013-docs-workshop-preview.adoc
+++ b/news/oscon-2013-docs-workshop-preview.adoc
@@ -17,7 +17,7 @@ At OSCON 2013, we'll work with you to reduce the friction of creating content by
 [caption=""]
 image::http://cdn.oreillystatic.com/en/assets/1/event/95/oscon2013_attending_300x250.png[OSCON banner, 260, 200, link="https://en.oreilly.com/oscon2013/public/register/order", role="right"]
 
-Join us on Tuesday, July 23 at our workshop titled {session-link} to learn about tools and techniques that lighten your documentation workload and jumpstart your content strategy. 
+Join us on Tuesday, July 23 at our workshop titled {session-link} to learn about tools and techniques that lighten your documentation workload and jumpstart your content strategy.
 To attend, register for OSCON 2013, then sign up for the workshop!
 
 // NOTE can't use admonition as it breaks the float of the previous image
@@ -34,14 +34,14 @@ Plain text *embellished* with _subtle_ markup.
 
 Indeed, that's the focus of the lightweight markup language http://asciidoctor.org/docs/what-is-asciidoc[AsciiDoc].
 The AsciiDoc syntax feels natural and that keeps you focused on the content.
-Content written in AsciiDoc is easy to read and edit in raw form, which facilitates collaboration. 
+Content written in AsciiDoc is easy to read and edit in raw form, which facilitates collaboration.
 It can also be translated into HTML for presentation, hello web publishing!
 
 image::zurb-foundation-yeti.png[Zurb Foundation Yeti, 260, 160, link="http://foundation.zurb.com", role="thumb right"]
 
 === Next, we do some baking.
 
-After composing some documentation in AsciiDoc, we'll pull together our content into a cohesive website using the static site generators http://awestruct.org[Awestruct] and http://jekyllrb.com[Jekyll]. 
+After composing some documentation in AsciiDoc, we'll pull together our content into a cohesive website using the static site generators http://awestruct.org[Awestruct] and http://jekyllrb.com[Jekyll].
 Then we'll leverage CSS frameworks like http://getbootstrap.com[Bootstrap] and http://foundation.zurb.com[Zurb Foundation] to dress up the content with an elegant look and feel.
 
 === It's push to publish!


### PR DESCRIPTION
Trailing whitespace is widely considered a bad idea, so this commit removes it from all the AsciiDoc files in the docs directory.

This change only affects the docs directory to keep the amount of changes something I could reasonably review. The only difference when processing the docs before and after this change is the last updated timestamp, so this change has no functional impact.

The command I used to perform this was:

``` sh
cd docs; for i in $(git grep -lP '\s+$'); do [[ -z ${i%%*.pdf} ]] && continue;  ruby -pi -e '$_.gsub!(/\s+$/, "\n")' $i; done
```
