### PR TITLE
Update install-and-use-asciidoctor-java-integration.adoc

### DIFF
--- a/docs/install-and-use-asciidoctor-java-integration.adoc
+++ b/docs/install-and-use-asciidoctor-java-integration.adoc
@@ -125,10 +125,10 @@ Use +render+ to render a string.
 .Rendering a string
 ----
 //...
-import java.util.Collections;
+import java.util.HashMap;
 //...
 String rendered = asciidoctor.render(
-    "AsciiDoc is *easy*!", Collections.<String,Object>emptyMap());
+    "AsciiDoc is *easy*!", new HashMap<String, Object>());
 System.out.println(rendered);
 ----
 
@@ -138,10 +138,10 @@ System.out.println(rendered);
 .Rendering a file
 ----
 //...
-import java.util.Collections;
+import java.util.HashMap;
 //...
 String rendered = asciidoctor.renderFile(
-    new File("sample.adoc"), Collections.<String,Object>emptyMap());
+    new File("sample.adoc"), new HashMap<String, Object>());
 System.out.println(rendered);
 ----
 


### PR DESCRIPTION
Corrected two examples that show the use of Collections.<String,Object>emptyMap() to create an empty map as the options parameter. Doing this results in a Java UnsupportedOperationException at runtime because AsciiDoctor is trying to put something in the immutable map that's returned (see stack trace below).

java.lang.UnsupportedOperationException
    at java.util.AbstractMap.put(AbstractMap.java:203)
    at org.asciidoctor.internal.JRubyAsciidoctor.addRubyRuntimeAsAttribute(JRubyAsciidoctor.java:174)
    at org.asciidoctor.internal.JRubyAsciidoctor.renderFile(JRubyAsciidoctor.java:158)
