### PR TITLE
Update the number of native backends

### DIFF
--- a/docs/_includes/output-format.adoc
+++ b/docs/_includes/output-format.adoc
@@ -9,7 +9,7 @@ The Asciidoctor processor parses an AsciiDoc document and converts it to a varie
 The processor produces the output format by using a backend that you specify with the `-b` (`--backend`) command line option.
 If no backend is indicated, the processor uses the default backend (`html5`).
 
-Asciidoctor has three native backends.
+Asciidoctor has four native backends.
 
 `html5`:: HTML 5 markup styled with CSS3.
 Asciidoctor's default backend.


### PR DESCRIPTION
The list of native backends has 4 items now; update the preceding text
to match.
