### PR TITLE
fixed admonition label for Important

### DIFF
--- a/docs/_includes/asciidoc-article-template.adoc
+++ b/docs/_includes/asciidoc-article-template.adoc
@@ -75,7 +75,7 @@ ____
 
 == First level heading
 
-TIP: There are five admonition labels: Tip, Note, Information, Caution, and Warning.
+TIP: There are five admonition labels: Tip, Note, Important, Caution and Warning.
 
 // I am a comment and won't be rendered.
 


### PR DESCRIPTION
it was incorrectly labeled as Information. I remember them as Note for information and Important for danger.
