### PR TITLE
Correcting a typo in the Asciidoctor 1.5.0 release announcement

### DIFF
--- a/news/asciidoctor-1-5-0-released.adoc
+++ b/news/asciidoctor-1-5-0-released.adoc
@@ -140,7 +140,7 @@ We'd like to give special shout outs to the following people:
 * to *Peter Neubauer* for making the very first https://twitter.com/mojavelinux/status/486037855051862019[Asciidoctor t-shirt], which I wore for the release!
 
 I (Dan) would also like to thank *Sarah White* for her monstrous effort providing input into the software design, editing the user manual, updating the website, testing (read as: breaking) and establishing a documentation workflow for the project.
-Asciidoctor would not be what it is today with her dedication.
+Asciidoctor would not be what it is today without her dedication.
 
 Additional thanks to everyone who is using the project, advocating for better documentation and those who have participated in the growing ecosystem of sub-projects.
 The mission of Asciidoctor is to help you write, publish and communicate your content successfully, and enjoy doing it!


### PR DESCRIPTION
Changed:
"Asciidoctor would not be what it is today with her dedication"
to:
"Asciidoctor would not be what it is today without her dedication"
