### PR TITLE
Add XML syntax to tag includes

### DIFF
--- a/docs/_includes/include-lines-tags.adoc
+++ b/docs/_includes/include-lines-tags.adoc
@@ -73,6 +73,8 @@ snippet b
 
 Notice that none of the lines with the tag directives are displayed.
 
+NOTE: for XML files you can use the `<!-- tag::name[] -->` and `<!-- end::name[] -->` delimiters
+
 Alternately, you can select content by line number.
 
 ==== By line ranges


### PR DESCRIPTION
From the documentation it was not clear how to do tag includes with 
XML files. By adding a note it is clear how to do tag includes for XML files.
