### PR TITLE
Fix link targets from Quick Reference to User Manual.

### DIFF
--- a/docs/asciidoc-syntax-quick-reference.adoc
+++ b/docs/asciidoc-syntax-quick-reference.adoc
@@ -37,11 +37,11 @@ endif::awestruct[]
 :uri-literal: {user}/#literal-text-and-blocks
 :uri-admon: {user}/#admonition
 :uri-bold: {user}/#bold-and-italic
-:uri-quote: {user}/#quotation-marks-and-apostrophes
+:uri-quote: {user}/#curved
 :uri-sub: {user}/#subscript-and-superscript
-:uri-mono: {user}/#monospace
+:uri-mono: {user}/#mono
 :uri-css: {user}/#custom-styling-with-attributes
-:uri-pass: {user}/#passthrough-macros
+:uri-pass: {user}/#pass-mac
 :uri-mailinglist: https://discuss.asciidoctor.org
 :uri-char-xml: https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
 :uri-data-uri: https://developer.mozilla.org/en-US/docs/data_URIs


### PR DESCRIPTION
There were a few broken link targets.
