### PR TITLE
Ignore directories that begin with an underscore (including the _bin directory)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /.bundle/
 /.sass-cache/
 /.rbx/
-/_site/
-/_tmp/
+/_*/
 Gemfile.lock
 TODO


### PR DESCRIPTION
This directory is present at least on my system, and it contains a variety of programs that clearly shouldn't be checked into the repository.
