### PR TITLE
Clarify that an example works but is not the recommended style.

### DIFF
--- a/docs/_includes/o-list.adoc
+++ b/docs/_includes/o-list.adoc
@@ -13,7 +13,8 @@ Instinct might tell you to prefix each item with a number, like in this next lis
 include::ex-o-list.adoc[tags=base-num]
 ----
 
-Since the numbering is obvious, the AsciiDoc processor will insert the numbers for you if you omit them:
+The above works, but
+since the numbering is obvious, the AsciiDoc processor will insert the numbers for you if you omit them:
 
 [source]
 ----


### PR DESCRIPTION
The text was ambiguous about whether the given example works, and this patch resolves the ambiguity.
