### PR TITLE
Make text consistent with example.

### DIFF
--- a/docs/_includes/block.adoc
+++ b/docs/_includes/block.adoc
@@ -40,7 +40,7 @@ include::x-block.adoc[tags=meta-co]
 <2> Id: gettysburg
 <3> Block name: quote
 <4> attribution: Abraham Lincoln (Named block attribute)
-<5> citetitle: Dedication of the Soldiers' National Cemetery (Named block attribute)
+<5> citetitle: Address delivered at the dedication of the Cemetery at Gettysburg (Named block attribute)
 
 TIP: A block can have multiple block attribute lines.
 The attributes will be aggregated.

--- a/docs/_includes/ex-quote.adoc
+++ b/docs/_includes/ex-quote.adoc
@@ -6,7 +6,7 @@ Included in:
 ////
 
 // tag::bl[]
-[quote, Abraham Lincoln, Soldiers' National Cemetery Dedication]
+[quote, Abraham Lincoln, Address delivered at the dedication of the Cemetery at Gettysburg]
 ____
 Four score and seven years ago our fathers brought forth
 on this continent a new nation...

--- a/docs/_includes/x-block.adoc
+++ b/docs/_includes/x-block.adoc
@@ -14,7 +14,7 @@ User Manual: Blocks
 // tag::meta-co[]
 .Gettysburg Address // <1>
 [[gettysburg]] // <2>
-[quote, Abraham Lincoln, Soldiers' National Cemetery Dedication] // <3> <4> <5>
+[quote, Abraham Lincoln, Address delivered at the dedication of the Cemetery at Gettysburg] // <3> <4> <5>
 ____
 Four score and seven years ago our fathers brought forth
 on this continent a new nation...

--- a/docs/asciidoc-writers-guide.adoc
+++ b/docs/asciidoc-writers-guide.adoc
@@ -838,7 +838,7 @@ Here's an example of a quote block that includes all types of metadata:
 ----
 .Gettysburg Address
 [[gettysburg]]
-[quote, Abraham Lincoln, Soldiers' National Cemetery Dedication]
+[quote, Abraham Lincoln, Address delivered at the dedication of the Cemetery at Gettysburg]
 ____
 Four score and seven years ago our fathers brought forth
 on this continent a new nation...
@@ -856,7 +856,7 @@ Id:: gettysburg
 Style:: quote
 Named block attributes::
   attribution::: Abraham Lincoln
-  citetitle::: Dedication of the Soldiers' National Cemetery
+  citetitle::: Address delivered at the dedication of the Cemetery at Gettysburg
 
 TIP: A block can have multiple block attribute lines.
 The attributes will be aggregated.


### PR DESCRIPTION
The description of an example was inconsistent with the example itself.

The Gettysburg Address was given two different titles:
- Soldiers' National Cemetery Dedication
- Dedication of the Soldiers' National Cemetery
  This commit makes them consistent.
  If we aren't going to call it the "Gettysburg Address", then we might as well
  use Abraham Lincoln's preferred title, from the authoritative Bliss text:
  "Address delivered at the dedication of the Cemetery at Gettysburg"
