### PR TITLE
Added Asciidoclet tag

### DIFF
--- a/news/asciidoclet-announcement.adoc
+++ b/news/asciidoclet-announcement.adoc
@@ -2,7 +2,7 @@
 John Ericksen
 2013-06-03
 :revdate: 2013-06-03 23:47:37 -0600
-:awestruct-tags: [announcement, plugin]
+:awestruct-tags: [announcement, plugin, asciidoclet]
 :asciidoc-ref: http://asciidoc.org
 :asciidoctor-ref: link:/
 :aji-ref: https://github.com/asciidoctor/asciidoctor-java-integration


### PR DESCRIPTION
We should be able to reference both asciidoclet articles by tag.
