### PR TITLE
Correcting typos on sectlinks attribute

### DIFF
--- a/docs/_includes/sections.adoc
+++ b/docs/_includes/sections.adoc
@@ -90,7 +90,7 @@ To disable the auto-generation of section IDs, unset the `sectids` attribute:
 
 === Links
 // tag::link[]
-To turn section titles into links, enable the `sectlink` attribute.
+To turn section titles into links, enable the `sectlinks` attribute.
 The default Asciidoctor stylesheet displays linked section titles with the same color and styles as unlinked section titles.
 // end::link[]
 

--- a/docs/asciidoc-article.adoc
+++ b/docs/asciidoc-article.adoc
@@ -3,7 +3,7 @@
 :keywords: AsciiDoc, Asciidoctor, AsciiDoc template, Asciidoctor template, AsciiDoc article template, Asciidoctor article template, AsciiDoc example, Asciidoctor example, AsciiDoc table example, AsciiDoc list example, AsciiDoc heading example, AsciiDoc article example, AsciiDoc sidebar example, AsciiDoc image example, AsciiDoc listing example, AsciiDoc code example, AsciiDoc literal example, AsciiDoc quote example, AsciiDoc verse example, AsciiDoc footnote example, AsciiDoc link example, AsciiDoc cross reference example
 :awestruct-layout: base
 :sectanchors:
-:sectlink:
+:sectlinks:
 :linkattrs:
 :icons: font
 :source-highlighter: coderay

--- a/docs/asciidoc-asciidoctor-diffs-table.adoc
+++ b/docs/asciidoc-asciidoctor-diffs-table.adoc
@@ -1343,7 +1343,7 @@ d|+scaledwidth+ (image)
 |{y}
 |
 
-|sectlink
+|sectlinks
 |
 |{y}
 |// Where did I get this attribute from?

--- a/docs/asciidoctor-diagram.adoc
+++ b/docs/asciidoctor-diagram.adoc
@@ -6,7 +6,7 @@ Pepijn Van_Eeckhoudt <https://github.com/pepijnve[@pepijnve]>; Sarah White <http
 :compat-mode!:
 :toc: preamble
 :sectanchors:
-:sectlink:
+:sectlinks:
 :linkattrs:
 :numbered!:
 :icons: font
@@ -42,7 +42,7 @@ You can install it using the `gem` command or via Bundler by adding it to your a
 You can install the Asciidoctor Diagram gem by typing `gem install` in the CLI.
 
  $ gem install asciidoctor-diagram --pre
- 
+
 IMPORTANT: The `--pre` flag is required to use Asciidoctor Diagram with Asciidoctor 1.5.0 until Asciidoctor Diagram 1.2.0 is released.
 Otherwise, you'll get the version that only works with Asciidoctor 0.1.4.
 


### PR DESCRIPTION
Attribute `sectlinks` was present without a 's' in the doc and some example.
