### PR TITLE
Document that we support Ruby 2.1.

### DIFF
--- a/docs/_includes/install-upgrade-asciidoctor.adoc
+++ b/docs/_includes/install-upgrade-asciidoctor.adoc
@@ -11,7 +11,8 @@ Asciidoctor requires one of the following implementations of Ruby:
 
 * Ruby 1.8.7
 * Ruby 1.9.3
-* Ruby 2.0.0
+* Ruby 2.0
+* Ruby 2.1
 * JRuby 1.7.5 (Ruby 1.8 and 1.9 modes)
 * Rubinius 2.0 (Ruby 1.8 and 1.9 modes)
 * Opal (Javascript)

--- a/docs/what-is-asciidoctor.adoc
+++ b/docs/what-is-asciidoctor.adoc
@@ -55,5 +55,6 @@ The Asciidoctor cli, link:/man/asciidoctor/[+asciidoctor+], is a drop-in replace
 
 == System requirements
 
-Asciidoctor is published as a RubyGem and currently works with Ruby 1.8.7, Ruby 1.9.3, Ruby 2.0.0, JRuby 1.7.2 and Rubinius 1.2.4 on Linux, Mac and Windows. 
+Asciidoctor is published as a RubyGem and currently works with Ruby 1.8.7, Ruby
+1.9.3, Ruby 2.0, Ruby 2.1, JRuby 1.7.2 and Rubinius 1.2.4 on Linux, Mac and Windows. 
 We expect it will work with other versions of Ruby as well.


### PR DESCRIPTION
There were two places we didn't specify that we supported 2.1.  I chose 2.1._x_ because 2.1 versions are coming out rapidly enough that I didn't want to hard-code 2.1.5 and then have to fix it later.  Let me know if you'd prefer just "2.1" or something else entirely.