### PR TITLE
Fix a typo 'throughtout->throughout'

### DIFF
--- a/docs/_includes/para-line-break.adoc
+++ b/docs/_includes/para-line-break.adoc
@@ -33,7 +33,7 @@ include::ex-text.adoc[tags=hb-p]
 
 Alternatively, you can preserve line breaks throughout your whole document by adding the `hardbreaks` attribute to the document's header.
 
-.Line breaks preserved throughtout the document using the hardbreaks attribute
+.Line breaks preserved throughout the document using the hardbreaks attribute
 [source]
 ----
 include::ex-text.adoc[tags=hb-attr]


### PR DESCRIPTION
A liitle typo in the Writer's Guide