### PR TITLE
Section Titles (Headers -> Headings)

### DIFF
--- a/docs/asciidoc-syntax-quick-reference.adoc
+++ b/docs/asciidoc-syntax-quick-reference.adoc
@@ -234,7 +234,7 @@ include::{includedir}/ex-header-attr.adoc[tags=b-base]
 ----
 
 [[section-titles]]
-== Section Titles (Headers)
+== Section Titles (Headings)
 
 .Article doctype
 ----


### PR DESCRIPTION
(very) minor change

Section titles are wrongly called headers instead of headings. This change will remove a potential ambiguity between "document header" and "headers", and make it consistent with the rest of the text (ex. in the Markdown Compatibility section where the term headings is being used).