### PR TITLE
Update the download link of the Firefox addon

### DIFF
--- a/docs/editing-asciidoc-with-live-preview.adoc
+++ b/docs/editing-asciidoc-with-live-preview.adoc
@@ -4,7 +4,7 @@ Dan Allen; Guillaume Grossetie
 :uri-firefox-addon: https://addons.mozilla.org/fr/firefox/addon/asciidoctorjs-live-preview
 :uri-opera-extension: https://addons.opera.com/fr/extensions/details/asciidoctorjs-live-preview
 :uri-chrome-extension-dd: https://github.com/asciidoctor/asciidoctor-chrome-extension/releases/download/v1.5.1.100/asciidoctor-chrome-extension.nex
-:uri-firefox-addon-dd: https://github.com/asciidoctor/asciidoctor-firefox-addon/releases/download/v0.2.3/asciidoctor-firefox-addon.xpi
+:uri-firefox-addon-dd: https://github.com/asciidoctor/asciidoctor-firefox-addon/releases/download/v0.3.0/asciidoctor-firefox-addon.xpi
 :uri-opera-extension-dd: https://github.com/asciidoctor/asciidoctor-chrome-extension/releases/download/v1.5.1.100/asciidoctor-chrome-extension.nex
 :experimental:
 :awestruct-layout: base


### PR DESCRIPTION
Version 0.3.0 is available with Asciidoctor 1.5.2.js and Opal 0.6.3