### PR TITLE
Table attribute 'grid' works just fine

### DIFF
--- a/docs/_includes/sum-table.adoc
+++ b/docs/_includes/sum-table.adoc
@@ -47,7 +47,7 @@ d|`{vbar}`, `:`, `,`, `!`, or a user defined attribute
 .4+|draws boundary lines between rows and columns
 |all
 |default, draws boundary lines around each cell
-.4+|Not yet implemented in Asciidoctor.
+.4+|
 
 |cols
 |draws boundary lines between columns

--- a/docs/_includes/table-formatting.adoc
+++ b/docs/_includes/table-formatting.adoc
@@ -117,4 +117,4 @@ include::ex-table.adoc[tags=base-h]
 [frame="none"]
 include::ex-table.adoc[tags=base-h]
 
-NOTE: At this time, Asciidoctor has not implemented the `float`, `align`, `halign`, `valign`, or `grid` attributes.
+NOTE: At this time, Asciidoctor has not implemented the `float`, `align`, `halign`, or `valign` attributes.


### PR DESCRIPTION
All values for grid appear functional: all, cols, rows, none.