### PR TITLE
Change Links to relative files

### DIFF
--- a/docs/_includes/ex-url.adoc
+++ b/docs/_includes/ex-url.adoc
@@ -49,11 +49,11 @@ Chat with other Asciidoctor users in the irc://irc.freenode.org/#asciidoctor[Asc
 // end::css[]
 
 // tag::link[]
-link:editing-asciidoc-with-live-preview[Editing with Live Preview]
+link:protocol.json[Open the JSON file]
 // end::link[]
 
 // tag::hash[]
-link:editing-asciidoc-with-live-preview/#livereload[LiveReload]
+link:external.html#livereload[LiveReload]
 // end::hash[]
 
 // tag::b-base[]

--- a/docs/_includes/ex-xref.adoc
+++ b/docs/_includes/ex-xref.adoc
@@ -17,6 +17,10 @@ Learn how to <<link-macro-attributes,use attributes within the link macro>>.
 Refer to link:document-b.html#section-b[Section B] for more information.
 // end::bad[]
 
+// tag::base-inter-top[]
+Refer to <<document-b.adoc#,Document B>> for more information.
+// end::base-inter-top[]
+
 // tag::base-inter[]
 Refer to <<document-b.adoc#section-b,Section B>> for more information.
 // end::base-inter[]

--- a/docs/_includes/url-relative.adoc
+++ b/docs/_includes/url-relative.adoc
@@ -5,14 +5,14 @@ Included in:
 - writers-guide
 ////
 
-If you want to link to a file relative to the current document, use the `link` macro in front of the file name.
+If you want to link to an external file relative to the current document, use the `link` macro in front of the file name.
 
 [source]
 ----
 include::ex-url.adoc[tags=link]
 ----
 
-To link directly to a section in the document, append a hash (`#`) followed by the section's ID to the end of the file name.
+If your file is an HTML file, you can link directly to a section in the document, append a hash (`#`) followed by the section's ID to the end of the file name.
 
 [source]
 ----

--- a/docs/_includes/xref-relative.adoc
+++ b/docs/_includes/xref-relative.adoc
@@ -1,0 +1,39 @@
+////
+Included in:
+
+- writers-guide
+////
+
+Cross references can also be used to create a link to a file relative to the current document.
+For links to another AsciiDoc document, this is the preferred way.
+
+The trailing hash (`#`) means that you refer to the top of the document.
+
+.Cross reference to the top of a relative Asciidoc document
+[source]
+----
+include::ex-xref.adoc[tags=base-inter-top]
+----
+
+.Rendered cross reference to the top of a relative Asciidoc document
+====
+include::ex-xref.adoc[tags=base-inter-top]
+====
+
+
+To link directly to a section in the document, append the section's ID after the hash (`#`)
+
+.Cross reference to a specific section of a relative Asciidoc document
+[source]
+----
+include::ex-xref.adoc[tags=base-inter]
+----
+
+.Rendered cross reference to a specific section of a relative Asciidoc document
+====
+include::ex-xref.adoc[tags=base-inter]
+====
+
+In both cases, this syntax will also work if you are inside the document you are referring to.
+This is useful if you are sharing the same link across multiple documents.
+

--- a/docs/asciidoc-writers-guide.adoc
+++ b/docs/asciidoc-writers-guide.adoc
@@ -360,11 +360,13 @@ include::{includedir}/url.adoc[tags=attr]
 
 include::{includedir}/url-relative.adoc[]
 
-You can also create links that refer to sections within the current document.
+For links to relative AsciiDoc documents cross references should be used.
 
-==== Internal cross references
+==== Cross references
 
 include::{includedir}/xref.adoc[]
+
+include::{includedir}/xref-relative.adoc[]
 
 Image references are similar to links since they are also references to URLs or files.
 The difference, of course, is that they display the image in the document.


### PR DESCRIPTION
As discussed on the mailing list: [Link to an other document ](http://discuss.asciidoctor.org/Link-to-an-other-document-td2857.html) the section [Links to relative files](http://asciidoctor.org/docs/asciidoc-writers-guide/#links-to-relative-files) of the "AsciiDoc Writer’s Guide" needs to be updated.