### PR TITLE
Add section with Asciidoctor extensions

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -1,0 +1,20 @@
+= Extensions
+:awestruct-layout: base
+:toc:
+:sectanchors:
+:icons: font
+:source-highlighter: highlight.js
+ifndef::awestruct[]
+:idprefix:
+:idseparator: -
+endif::awestruct[]
+
+[cols="1,0,5"]
+|====
+|Name |Runtime |Description
+
+|link:https://github.com/allati/asciidoctor-extension-monotree[MonoTree]
+|AsciidoctorJ
+|Visualizes tree-like structures. It takes names for a tree node and it’s nesting level as an input and draws a tree as an output.
+
+|====

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -111,6 +111,8 @@ http://www.noteshare.io/section/asciidoctor-latex-manual-intro[Convert AsciiDoc 
 
 * link:install-and-use-asciidoctorjs/[How do I install and use Asciidoctor.js?] (Experimental)
 
+* link:extensions/[Extension list]
+
 == Contribute to Asciidoctor
 
 //* link:/#submitting-an-issue[How do I report a bug?]


### PR DESCRIPTION
A followup to this [post](http://discuss.asciidoctor.org/MonoTree-extension-tp2903p2946.html) on asciidoctor forum. I doubt that this change can be considered "complete", but it's still something to start from.

I wasn't able to check if awestruct processes this change correctly - spent several hours trying to configure environment on Windows 7 (different combinations of ruby versions, build tools, etc.), but failed.