### PR TITLE
Add Appendix section in user-manual

### DIFF
--- a/docs/_includes/appendix.adoc
+++ b/docs/_includes/appendix.adoc
@@ -1,0 +1,48 @@
+////
+Included in:
+
+- user-manual
+////
+
+You can define that some sections are appendix sections by adding the `[appendix]` marker before the section header.
+
+----
+[appendix]
+== Copyright and License
+----
+
+Sections marked as appendix have different header, built as follow:
+
+* A fixed prefix ("`Appendix`" is the default value)
+* Letters are used to number the section (A, B, C...)
+* A colon
+* The section title
+
+The prefix can be modified with the `appendix-caption` attribute.
+It can be unset with:
+
+[source]
+----
+: appendix-caption!:
+----
+
+Or set to a different value with
+[source]
+----
+: appendix-caption: App
+----
+
+Appendix sections can be combined with subsections.
+Example:
+
+[source]
+----
+include::ex-appendix.adoc[tags=app]
+----
+
+The sections will be numbered as follows:
+
+[source]
+----
+include::ex-appendix.adoc[tags=app-out]
+----

--- a/docs/_includes/ex-appendix.adoc
+++ b/docs/_includes/ex-appendix.adoc
@@ -1,0 +1,35 @@
+////
+Included in:
+
+- user-manual: Appendix
+////
+
+// tag::app[]
+:appendix-caption: App
+:numbered:
+
+== Title
+
+=== Subsection
+
+[appendix]
+== First Appendix
+
+=== First subsection
+
+=== Second subsection
+
+[appendix]
+== Second Appendix
+// end::app[]
+
+// tag::app-out[]
+1. Title
+1.1. Subsection
+
+App A: First Appendix
+A.1. First subsection
+A.2. Second subsection
+
+App B: Second Appendix
+// end::app-out[]

--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -1090,7 +1090,7 @@ include::{includedir}/book-part.adoc[]
 [[user-appendix]]
 == Appendix
 
-NOTE: Section pending
+include::{includedir}/appendix.adoc[]
 
 [[user-glossary]]
 == Glossary


### PR DESCRIPTION
With the information found [in the mailing list](http://discuss.asciidoctor.org/Appendix-sectnums-td706.html) and in [asciidoctor/issues/683](https://github.com/asciidoctor/asciidoctor/issues/683), I was able to propose some text for the `Appendix` section of the [User Manual](asciidoctor.org/docs/user-manual/).

Current text is:

    NOTE: Section pending
