### PR TITLE
Precision for ordered list

### DIFF
--- a/docs/_includes/ex-o-list.adoc
+++ b/docs/_includes/ex-o-list.adoc
@@ -18,11 +18,24 @@ Included in:
 . Neutrons
 // end::base[]
 
+// tag::base-start[]
+[start=4]
+ . Step four
+ . Step five
+ . Step six
+// end::base-start[]
+
 // tag::base-num[]
 1. Protons
 2. Electrons
 3. Neutrons
 // end::base-num[]
+
+// tag::base-num-start[]
+4. Step four
+5. Step five
+6. Step six
+// end::base-num-start[]
 
 // tag::base-t[]
 .Parts of an atom

--- a/docs/_includes/o-list.adoc
+++ b/docs/_includes/o-list.adoc
@@ -25,6 +25,23 @@ include::ex-o-list.adoc[tags=base]
 include::ex-o-list.adoc[tags=base]
 ====
 
+If you decide to use number for your ordered list, you have to keep them sequential.
+This differs from other lightweight markup languages.
+It's one way to adjust the numbering offset of a list.
+For instance, you can type:
+
+[source]
+----
+include::ex-o-list.adoc[tags=base-num-start]
+----
+
+However, in general the best practice is to use the `start` attribute to configure this sort of thing:
+
+[source]
+----
+include::ex-o-list.adoc[tags=base-start]
+----
+
 You can give a list a title by prefixing the line with a dot immediately followed by the text (without leaving any space after the dot).
 
 Here's an example of a list with a title:
@@ -37,3 +54,4 @@ include::ex-o-list.adoc[tags=base-t]
 ====
 include::ex-o-list.adoc[tags=base-t]
 ====
+


### PR DESCRIPTION
As discussed on the [mailing list](http://discuss.asciidoctor.org/Number-lists-give-warnings-td2526.html), ordered list using number needs to be sequential.

This pull request adds more information in the ordered list section.
