### PR TITLE
Fix autoid closing tag in sections.adoc

### DIFF
--- a/docs/_includes/sections.adoc
+++ b/docs/_includes/sections.adoc
@@ -98,7 +98,7 @@ To disable the auto-generation of section IDs, unset the `sectids` attribute:
 IMPORTANT: Asciidoctor permits all valid UTF-8 characters in section IDs.
 If you are generating a PDF from AsciiDoc using a2x and dblatex, see http://aerostitch.github.io/misc/asciidoc/asciidoc-title_uft8.html[Using UTF-8 titles with a2x] to learn about the required `latex.encoding=utf8` switch.
 
-// end::id[]
+// end::autoid[]
 
 === Links
 // tag::link[]


### PR DESCRIPTION
The #asciidoctor user manual is broken: 

* 18.3. Links
* 18.4. Anchors
* 18.5. Numbering
* 18.6. Links
* 18.7. Anchors
* 18.8. Numbering
* …

Bug introduced with 00d4ea2b0b13ed78efb92e013b3c02a62a731572