### PR TITLE
Spelling fixes in the website

### DIFF
--- a/docs/_includes/apply-theme.adoc
+++ b/docs/_includes/apply-theme.adoc
@@ -7,7 +7,7 @@ This document is included in:
 - user-manual
 ////
 
-A custom stylesheet can be stored in the same directory as your document or in a seperate directory.
+A custom stylesheet can be stored in the same directory as your document or in a separate directory.
 And, like the default stylesheet, you can link your document to your custom stylesheet or embed it.
 If the stylesheet is in the same directory as your document, you can apply it when rendering your document to HTML from the CLI.
 

--- a/docs/_includes/u-list.adoc
+++ b/docs/_includes/u-list.adoc
@@ -49,7 +49,7 @@ include::ex-u-list.adoc[tags=base-alt]
 You should reserve the hyphen for lists that only have a single level because the hyphen marker (`-`) doesn't work for nested lists.
 Now that we've mentioned nested lists, let's go to the next section and learn how to create lists with multiple levels.
 
-.Seperating Lists
+.Separating Lists
 ****
 If you have adjacent lists, they have the tendency to want to fuse together.
 To force the lists apart, place a line comment between them (`+//+`), offset on either side by a blank line (i.e., an end of list marker).


### PR DESCRIPTION
I was reading the nice website documentation and found a couple minor misspellings. So I fixed them, _separately_.