### PR TITLE
remove 'caution: copycss is broken' from docs

### DIFF
--- a/docs/_includes/apply-theme.adoc
+++ b/docs/_includes/apply-theme.adoc
@@ -5,6 +5,7 @@ Applying a theme
 This document is included in:
 
 - user-manual
+- produce-custom-themes-using-asciidoctor-stylesheet-factory
 ////
 
 A custom stylesheet can be stored in the same directory as your document or in a separate directory.
@@ -39,7 +40,7 @@ include::mysample-stylesdir.adoc[]
 ----
 
 After processing +mysample.adoc+, its HTML output (+mysample.html+), which includes the embedded +mystyles.css+ stylesheet, is created in the +mydocuments/+ directory.
- 
+
 ====
 image::mysample-stylesdir-dir.png[]
 ====
@@ -57,22 +58,19 @@ include::mysample-stylesdir-link.adoc[]
 After your document is rendered, notice that a copy of +mystyles.css+ was not created in the +mydocuments/+ directory.
 Unlike when you link to the default Asciidoctor stylesheet, any custom stylesheets you link to are not copied to the directory where your output is saved.
 
-CAUTION: The +copycss+ attribute, which would copy a custom stylesheet when a document is rendered, is broken.
-Watch https://github.com/asciidoctor/asciidoctor/issues/300[Issue #300] for updates. 
-
 [[style-nest-doc]]
 .Stylesheets and processing multiple nested documents
 ****
 When you are <<user-manual#process-multiple-source-files-from-the-cli,running Asciidoctor once across a nested set of documents>>, it's currently not possible to specify a single relative path for the +stylesdir+ attribute that would work for all of the documents.
-This is because the relative depth of the stylesheet's location differs for the documents in the subdirectories. 
+This is because the relative depth of the stylesheet's location differs for the documents in the subdirectories.
 One way to solve this problem is to maintain the path to +stylesdir+ in each document.
 
 Let's say you have three AsciiDoc documents saved in the following directory structure:
 
 ----
 /mydocuments
-  a.adoc 
-  b.adoc 
+  a.adoc
+  b.adoc
   /mynesteddocuments
     c.adoc
   /mystylesheets

--- a/docs/produce-custom-themes-using-asciidoctor-stylesheet-factory.adoc
+++ b/docs/produce-custom-themes-using-asciidoctor-stylesheet-factory.adoc
@@ -40,7 +40,7 @@ include::_includes/factory-setup.adoc[tag=gem]
 
 To build the stylesheets:
 
-. Navigate to the Asciidoctor stylesheet factory directory on your system. 
+. Navigate to the Asciidoctor stylesheet factory directory on your system.
 . Run Compass's +compile+ command.
 
  $ compass compile
@@ -51,7 +51,7 @@ You can reference the stylesheets in [path]'stylesheets/' from your HTML file.
 == Applying a stylesheet to HTML
 
 Let's practice applying a stylesheet to a simple AsciiDoc file.
-If you're unfamiliar with the general commands needed to render and style a document created with the AsciiDoc syntax, you may want to review the {render-ref}[How Do I Render My Document guide] before proceeding. 
+If you're unfamiliar with the general commands needed to render and style a document created with the AsciiDoc syntax, you may want to review the {render-ref}[How Do I Render My Document guide] before proceeding.
 
 . Create an AsciiDoc file like the one below.
 . Save the file as [path]'sample.adoc'.
@@ -109,7 +109,7 @@ If you prefer to link the [path]'colony.css' stylesheet to the generated HTML ou
 If you inspect the [path]'sample.html' document, you should see that the stylesheet is linked to the rendered document.
 
  <link rel="stylesheet" href="../stylesheets/colony.css">
- 
+
 .Stylesheet images
 ****
 The Golo, Maker, and Riak themes include image assets.
@@ -121,7 +121,7 @@ For example, to apply the [path]'maker.css' stylesheet to [path]'sample.adoc':
 . Call the +stylesheet+ and +styledir+ attributes.
 
  $ asciidoctor -a stylesheet=maker.css -a stylesdir=../stylesheets sample.adoc
- 
+
 Navigate to [path]'sample.html' in your browser. The [path]'body-bh.png' image should add a graph paper-like background to your generated output.
 ****
 


### PR DESCRIPTION
This message: "The copycss attribute, which would copy a custom stylesheet when a document is rendered, is broken. Watch Issue #300 for updates." appears on the Custom Themes part of the documentation. According to https://github.com/asciidoctor/asciidoctor/issues/300, this is no longer the case. 