### PR TITLE
issue-481 document 'document' attributes, partial fix

### DIFF
--- a/docs/_includes/attr-data.adoc
+++ b/docs/_includes/attr-data.adoc
@@ -19,47 +19,38 @@ These attributes can be referenced anywhere in the document.
 //|Dont understand what this is
 //|{asciidoctor}
 
-// checked 1.5.2
 |asciidoctor-version 
 |Version of the processor
 |Example: {asciidoctor-version}
 
-// checked 1.5.2
 |backend 
 |Backend used to create the output file
 |Example: {backend}
 
-// checked 1.5.2
 |basebackend
 |html or docbook
 |Example: {basebackend}
 
-// checked 1.5.2
 |docdate 
-|Last modified date of the input document
+|Last modified date of the document
 |Does not check included files, so use with care. Example: {docdate}
 
-// checked 1.5.2
 |docdatetime 
-|Last modified date and time of the input document
+|Last modified date and time of the document
 |Example: {docdatetime}
 
-// checked 1.5.2
 |docdir 
-|Full path of the directory containing the input document
+|Full path of the directory containing the document
 |Example: {docdir}
 
-// checked 1.5.2
 |docfile 
-|Full path of the input document
+|Full path of the document
 |Example: {docfile}
 
-// checked
 |docname 
-|Name of the input document without extension
+|Name of the input document without path or extension
 |Example: {docname}
 
-// checked 1.5.2
 |doctime 
 |Last modified time 
 |Example: {doctime}
@@ -69,7 +60,6 @@ These attributes can be referenced anywhere in the document.
 // |The title of the document
 // |
 
-// checked 1.5.2
 |doctype 
 |Document’s doctype
 |article, manpage or book. Example: {doctype}
@@ -79,27 +69,22 @@ These attributes can be referenced anywhere in the document.
 //|Encoding of the input and output files
 //|Example: {encoding}
 
-// checked 1.5.2
 |filetype 
 |Extension of the output file name
 |Example: {filetype}
 
-// checked 1.5.2
 |localdate 
 |Date when rendered 
 |Example: {localdate}
 
-// checked 1.5.2
 |localdatetime 
 |Date and time when rendered 
 |Example: {localdatetime}
 
-// checked 1.5.2
 |localtime 
 |Time when rendered 
 |Example: {localtime}
 
-// checked 1.5.2
 |outdir 
 |Full path of the output directory
 |Example: {outdir}

--- a/docs/_includes/attr-data.adoc
+++ b/docs/_includes/attr-data.adoc
@@ -4,56 +4,106 @@ Included in:
 - user-manual: Built-in data attributes
 ////
 
-Asciidoctor includes numerous intrinsic attributes that are assigned values when the document is rendered.
-The values of these built-in data attributes are derived from how the document is processed and when and where is it processed.
+Asciidoctor includes numerous attributes that are assigned values when the document is rendered.
+The values of these attributes are derived from how the document is processed and when and where is it processed.
 These attributes can be referenced anywhere in the document.
 
 // tag::table[]
-.Built-in data attributes
-[width="70%",cols="1m,3"]
+.Document attributes - runtime information
+[cols="1m,2,2"]
 |===
-|Attribute |Description
+|Attribute |Description |Notes
 
-|asciidoctor
-|Calls the processor
+//|asciidoctor 
+//|Calls the processor
+//|Dont understand what this is
+//|{asciidoctor}
 
-|asciidoctor-version
+// checked 1.5.2
+|asciidoctor-version 
 |Version of the processor
+|Example: {asciidoctor-version}
 
-|backend
-|Backend used to render document
+// checked 1.5.2
+|backend 
+|Backend used to create the output file
+|Example: {backend}
 
-|docdate
-|Last modified date
+// checked 1.5.2
+|basebackend
+|html or docbook
+|Example: {basebackend}
 
-|docdatetime
-|Last modified date and time
+// checked 1.5.2
+|docdate 
+|Last modified date of the input document
+|Does not check included files, so use with care. Example: {docdate}
 
-|docdir
-|Full path of the document directory
+// checked 1.5.2
+|docdatetime 
+|Last modified date and time of the input document
+|Example: {docdatetime}
 
-|docfile
-|Full path of the document file
+// checked 1.5.2
+|docdir 
+|Full path of the directory containing the input document
+|Example: {docdir}
 
-|docname
-|Basename of the document file (no directory or file extension)
+// checked 1.5.2
+|docfile 
+|Full path of the input document
+|Example: {docfile}
 
-|doctime
-|Last modified time
+// checked
+|docname 
+|Name of the input document without extension
+|Example: {docname}
 
-|doctitle
-|The title of the document
+// checked 1.5.2
+|doctime 
+|Last modified time 
+|Example: {doctime}
 
-|doctype
-|Document's doctype (e.g., article)
+// This isn't a document attribute, it is a header attribute and is already in <<header-summary>>
+// |doctitle
+// |The title of the document
+// |
 
-|localdate
-|Local date when rendered
+// checked 1.5.2
+|doctype 
+|Document’s doctype
+|article, manpage or book. Example: {doctype}
 
-|localdatetime
-|Local date and time when rendered
+// This used to work in 1.5.2 (I think) but not in 1.5.4. Assume it was removed because everything is now forced to UTF-8.
+//|encoding 
+//|Encoding of the input and output files
+//|Example: {encoding}
 
-|localtime
-|Local time when rendered
+// checked 1.5.2
+|filetype 
+|Extension of the output file name
+|Example: {filetype}
+
+// checked 1.5.2
+|localdate 
+|Date when rendered 
+|Example: {localdate}
+
+// checked 1.5.2
+|localdatetime 
+|Date and time when rendered 
+|Example: {localdatetime}
+
+// checked 1.5.2
+|localtime 
+|Time when rendered 
+|Example: {localtime}
+
+// checked 1.5.2
+|outdir 
+|Full path of the output directory
+|Example: {outdir}
+
 |===
 // end::table[]
+

--- a/docs/_includes/multiple-include.adoc
+++ b/docs/_includes/multiple-include.adoc
@@ -1,0 +1,35 @@
+// Including a fragment more than once in the same document
+
+A document can include the same file any number of times.
+The problem comes if there are IDs in the included file; the output document (HTML or DocBook) will then have duplicate IDs which will make it not well-formed.
+To fix this, make the ID depend on a variable in the main document.
+
+For example, say you want to include the same subsection describing a bike chain in both the operation and maintenance chapters:
+
+----
+= Bike Manual
+
+:chapter: oper
+== Operation
+
+\include::fragment-chain.ad[]
+
+:chapter: maint
+== Maintenance
+
+\include::fragment-chain.ad[]
+----
+
+Write 'fragment-chain.ad' as:
+
+----
+[id='{chapter}-chain']
+=== Chain
+
+See xref:{chapter}-chain[].
+----
+
+The first time it is included its ID is 'oper-chain', and the second time it is 'maint-chain'.
+
+Note that for this to work, you have to use the longhand forms of both the ID assignment and the cross-reference.
+The single quotes around the variable name in the assignment are needed to force variable substitution.

--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -1052,6 +1052,10 @@ include::{includedir}/relative-include.adoc[]
 
 include::{includedir}/uri-include.adoc[]
 
+=== Include a fragment more than once in the same document
+
+include::{includedir}/multiple-include.adoc[]
+
 == Docinfo file
 
 include::{includedir}/docinfo.adoc[]


### PR DESCRIPTION
I have expanded the in-body table first, so it can be included into the appendix later.

Added an example/notes column (maybe should be hard coded?); 
deleted asciidoctor because I don't know what it does; 
deleted doctitle because it is documented elsewhere; 
added basebackend, filetype and outdir;
consistently use 'document' for the input file and 'output file' for the output.