### PR TITLE
resolves #79 by adding the following to the existing documentation:

### DIFF
--- a/docs/_includes/video.adoc
+++ b/docs/_includes/video.adoc
@@ -6,6 +6,15 @@ Included in:
 
 The `video` macro supports displaying videos stored relatively as well as externally.
 
+While Asciidoctor supports many popular video formats, their support in browsers is a constantly changing landscape.
+
+.A note about serving video in browsers
+Wherever possible, you should use a video hosting service like YouTube or Vimeo to serve videos in online documentation formats.
+These services specialize in streaming optimized video to the browser, with the lowest latency possible given hardware, software, and network capabilities of the device viewing the video.
+
+NOTE: For a canonical list of supported web video formats and their interaction with modern browsers, see the  https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats#Browser_compatibility[Mozilla Developer Supported Media Formats] documentation.
+
+.Basic video file include
 [source]
 ----
 include::ex-video.adoc[tags=base]
@@ -14,6 +23,7 @@ include::ex-video.adoc[tags=base]
 You can control the video settings using additional attributes on the macro.
 For instance, you can offset the start time of playback using the `start` attribute and enable autoplay using the `autoplay` option.
 
+.Setting attributes for local video playback
 [source]
 ----
 include::ex-video.adoc[tags=attr]

--- a/docs/_includes/video.adoc
+++ b/docs/_includes/video.adoc
@@ -9,7 +9,7 @@ The `video` macro supports displaying videos stored relatively as well as extern
 While Asciidoctor supports many popular video formats, their support in browsers is a constantly changing landscape.
 
 .A note about serving video in browsers
-Wherever possible, you should use a video hosting service like YouTube or Vimeo to serve videos in online documentation formats. These services specialize in serving video in-browser, with the lowest latency possible given hardware, software, and network capabilities of the device viewing the video.
+Wherever possible, you should use a video hosting service like YouTube or Vimeo to serve videos in online documentation formats. These services specialize in streaming optimized video to the browser, with the lowest latency possible given hardware, software, and network capabilities of the device viewing the video.
 
 NOTE: For a canonical list of supported web video formats and their interaction with modern browsers, see the  https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats#Browser_compatibility[Mozilla Developer Supported Media Formats] documentation.
 

--- a/docs/_includes/video.adoc
+++ b/docs/_includes/video.adoc
@@ -9,7 +9,8 @@ The `video` macro supports displaying videos stored relatively as well as extern
 While Asciidoctor supports many popular video formats, their support in browsers is a constantly changing landscape.
 
 .A note about serving video in browsers
-Wherever possible, you should use a video hosting service like YouTube or Vimeo to serve videos in online documentation formats. These services specialize in streaming optimized video to the browser, with the lowest latency possible given hardware, software, and network capabilities of the device viewing the video.
+Wherever possible, you should use a video hosting service like YouTube or Vimeo to serve videos in online documentation formats.
+These services specialize in streaming optimized video to the browser, with the lowest latency possible given hardware, software, and network capabilities of the device viewing the video.
 
 NOTE: For a canonical list of supported web video formats and their interaction with modern browsers, see the  https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats#Browser_compatibility[Mozilla Developer Supported Media Formats] documentation.
 

--- a/docs/_includes/video.adoc
+++ b/docs/_includes/video.adoc
@@ -6,15 +6,6 @@ Included in:
 
 The `video` macro supports displaying videos stored relatively as well as externally.
 
-While Asciidoctor supports many popular video formats, their support in browsers is a constantly changing landscape.
-
-.A note about serving video in browsers
-Wherever possible, you should use a video hosting service like YouTube or Vimeo to serve videos in online documentation formats.
-These services specialize in streaming optimized video to the browser, with the lowest latency possible given hardware, software, and network capabilities of the device viewing the video.
-
-NOTE: For a canonical list of supported web video formats and their interaction with modern browsers, see the  https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats#Browser_compatibility[Mozilla Developer Supported Media Formats] documentation.
-
-.Basic video file include
 [source]
 ----
 include::ex-video.adoc[tags=base]
@@ -23,7 +14,6 @@ include::ex-video.adoc[tags=base]
 You can control the video settings using additional attributes on the macro.
 For instance, you can offset the start time of playback using the `start` attribute and enable autoplay using the `autoplay` option.
 
-.Setting attributes for local video playback
 [source]
 ----
 include::ex-video.adoc[tags=attr]


### PR DESCRIPTION
- A paragraph describing the advantages of using a hosted video service over local video files.
- The addition of a link to the Mozilla Developer docs on supported video formats.
- whitespace between paragraphs in YouTube/Vimeo section to improve readability.