### PR TITLE
Document Model: exten-doc-model.adoc now available for content expansion (Issue #323)

### DIFF
--- a/docs/_includes/exten-doc-model.adoc
+++ b/docs/_includes/exten-doc-model.adoc
@@ -1,0 +1,31 @@
+////
+Included in:
+
+- user-manual: Extensions: Document Model
+////
+
+#This section is still under development. Dan Allen has knowledge about the document model and will develop this section further.#
+
+Here's the current list of `content_model` values:
+
+NOTE: Context names are unbounded. They merely instruct the processor which convert handler method to call.
+
+* `:compound` - zero or more child blocks
+* `:simple` - paragraph content
+* `:verbatim` - literal content
+* `:raw` - unprocessed content
+* `:skip` - drop the content
+* `:empty` - don't expect content (mostly relevant for macros)
+* `:attributes` - parse as attributes (only relevant for macros)
+
+Here's the current list of built-in structural containers (aka delimited blocks) that can support block extensions.
+Each structural container is named by their default context:
+
+* `:open` - --
+* `:example` - ====
+* `:sidebar` - {asterisk}{asterisk}{asterisk}{asterisk}
+* `:literal` - ....
+* `:listing` - ----
+* `:quote` - ____
+* `:pass` - {plus}{plus}{plus}{plus}
+* `:paragraph`

--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -1611,6 +1611,13 @@ include::{includedir}/exten-intro.adoc[]
 
 include::{includedir}/exten-point.adoc[]
 
+== Document Model
+
+.Discuss and Contribute
+TIP: Use {uri-ad-org-issues}/323[Issue 323] to drive development of this section. Your contributions make a difference. No contribution is too small.
+
+include::{includedir}exten-doc-model.adoc[]
+
 == Example Extensions
 
 Below are several examples of extensions and how they are registered.


### PR DESCRIPTION
user-manual.adoc now contains:
- a Document Model heading
- a contribute prompt pointing to #323 
- A link to the new include.

exten-doc-model.adoc is new and contains:
- the contents of asciidoctor/asciidoctor-documentation#30 in tersely formatted asciidoc
- a starting point for more elaborate content on the Document Model.
