### PR TITLE
resolves #64 with the following improvements:

### DIFF
--- a/docs/_includes/formatting-marks.adoc
+++ b/docs/_includes/formatting-marks.adoc
@@ -1,0 +1,86 @@
+////
+== Constrained and unconstrained formatting marks
+
+- User manual
+////
+
+Two categories of formatting marks (or _quotes_ as they are referred to in AsciiDoc syntax) control how text is displayed after it is parsed.
+
+=== Constrained quotes
+
+In short, "constrained" means *around* a word.
+
+Constrained quotes are single characters that are placed around a word.
+The "around" is defined by the fact that word characters do not appear outside the marks.
+
+You use this form when the word stands alone.
+
+.When the word stands alone
+[source]
+----
+That is *strong* stuff!
+----
+
+You can also use this form when there are multiple words.
+
+.When there are multiple words
+[source]
+----
+That is *really strong* stuff!
+----
+
+Or when the word is adjacent to punctuation, like an exclamation mark.
+
+.When the word is adjacent to punctuation
+[source]
+----
+This stuff sure is *strong*!
+----
+
+=== Unconstrained quotes
+
+In short, "unconstrained" means anywhere *inside* a word.
+
+Unconstrained quotes are double-characters that are placed within a word.
+The "within" is defined by the fact that a word character appears directly outside one of the marks.
+
+.Unconstrained formatting
+[source]
+----
+She spells her name with an "`h`", as in Sara**h**.
+----
+
+=== Why are unconstrained formatting marks required?
+
+There are cases when it might seem logical to use constrained quotes, however unconstrained quotes are required.
+This happens because of the way the Asciidoctor parser (and the AsciiDoc Python parser) currently handles substitutions.
+
+Substitutions may be applied by the parser before getting to the formatting marks, in which case the characters adjacent to those marks may not be what you see in the original source.
+
+One such example is enclosing monospaced text inside quotation marks, such as "```endponts```".
+
+.Monospaced text inside quotes
+[source]
+----
+"```endpoints```"
+----
+
+Logic would suggest that you should be able to use the following syntax:
+
+[source]
+----
+"`endpoints`"
+----
+
+Specifying this only gives you "`endpoints`".
+
+[source]
+----
+"``endpoints``"
+----
+
+Adding another backtick gets closer, but the parser still ignores the constrained formatting marks and mistakenly believes you are trying to use the backticks in a literal sense.
+
+The parser is processing the markup too conservatively, and you have to double up the marks to coerce it into formatting the text to monospace.
+
+NOTE: The Asciidoctor parser is constantly maturing, thanks to the dedication of the community that supports it.

--- a/docs/_includes/formatting-marks.adoc
+++ b/docs/_includes/formatting-marks.adoc
@@ -84,3 +84,46 @@ Adding another backtick gets closer, but the parser still ignores the constraine
 The parser is processing the markup too conservatively, and you have to double up the marks to coerce it into formatting the text to monospace.
 
 NOTE: The Asciidoctor parser is constantly maturing, thanks to the dedication of the community that supports it.
+
+=== When should I use unconstrained quotes?
+
+Consider the following questions:
+
+* Is there a letter, number, underscore directly outside the formatting marks (on either side)?
+* Is there a semi-colon directly before the starting formatting mark?
+* Is there a space directly inside of the formatting mark?
+
+If you answered "yes" to any of these questions, you need to switch to unconstrained (double formatting) quotes.
+
+To help you determine whether a particular syntax pattern requires unconstrained quotes, consider the following syntactical situations.
+
+.Constrained or Unconstrained?
+[cols="2,2,2"]
+|===
+|Syntax |Result |What quote type?
+
+|Sara\__h__
+|Sara__h__
+|Unconstrained, because of the "a" to the left.
+
+|\\**B**old
+|**B**old
+|Unconstrained, because of the "o" to the right.
+
+|&endash;\\**2016**
+|&endash;**2016**
+|Unconstrained, because of the "&endash;" to the left of the emboldened number.
+
+|\\** bold **
+|** bold **
+|Unconstrained, because there are spaces directly inside the formatting marks.
+
+|\*2016*&endash;
+|*2016*&endash;
+|Constrained, because the & is not a letter, number, underscore, or semi-colon.
+
+|\*9*-to-\*5*
+|*9*-to-*5*
+|Constrained, because a hyphen is not a letter, number, underscore, or semi-colon.
+
+|===

--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -286,6 +286,10 @@ include::{includedir}/element.adoc[]
 .Discuss and Contribute
 TIP: Use {uri-ad-org-issues}/443[Issue 443] to drive development of this section. Your contributions make a difference. No contribution is too small.
 
+== Constrained and unconstrained formatting marks
+
+include::{includedir}/formatting-marks.adoc[]
+
 == Attributes
 
 include::{includedir}/attr.adoc[tags=intro]


### PR DESCRIPTION
* declare a constrained and unconstrained formatting marks section in the user guide.

Added a formatting marks include containing the following info:
- constrained formatting explanation
- unconstrained formatting explanation
- why unconstrained formatting is required.