### PR TITLE
Re #481 Create table of document attributes

### DIFF
--- a/docs/_includes/attr-data.adoc
+++ b/docs/_includes/attr-data.adoc
@@ -121,8 +121,8 @@ These attributes can be referenced anywhere in the document.
 
 |user-home
 |home directory of the current user.
-|If the safe mode is server or greater it resolves to ".."
-|
+If the safe mode is server or greater it resolves to ".."
+|/home/dave
 
 |===
 // end::table[]

--- a/docs/_includes/attr-data.adoc
+++ b/docs/_includes/attr-data.adoc
@@ -8,6 +8,7 @@ Added an example/notes column;
 deleted doctitle because it is documented elsewhere; 
 added basebackend, filetype and outdir;
 consistently use 'document' for the input file and 'output file' for the output.
+added safe-mode stuff
 ////
 
 Asciidoctor includes numerous attributes that are assigned values when the document is rendered.
@@ -23,12 +24,12 @@ These attributes can be referenced anywhere in the document.
 |asciidoctor 
 |Defined if the current processor is Asciidoctor.
 //|{asciidoctor}
-|(Empty string)
+|
 
 |asciidoctor-version 
 |Version of the processor.
 //|Example: {asciidoctor-version}
-|1.5.2
+|1.5.4
 
 |backend
 |Backend used to create the output file.
@@ -79,7 +80,7 @@ These attributes can be referenced anywhere in the document.
 |article
 
 |encoding 
-|Encoding of the input and output files
+|Encoding of the input and output files.
 |UTF-8
 
 |filetype 
@@ -106,6 +107,33 @@ These attributes can be referenced anywhere in the document.
 |Full path of the output directory
 //|Example: {outdir}
 |home/projects/bike/dist
+
+|safe-mode-level
+//={safe-mode-level}
+|Numeric value of safe-mode. UNSAFE is 0, SECURE is 20.
+|20
+
+|safe-mode-name
+//{safe-mode-name}
+|Text value of `safe-mode`.
+|SERVER
+
+|safe-mode-unsafe
+|Defined if `safe-mode` is UNSAFE.
+|
+
+|safe-mode-safe
+|Defined if `safe-mode` is SAFE.
+|
+
+|safe-mode-server
+|Defined if `safe-mode` is SERVER.
+|
+
+|safe-mode-secure
+|Defined if `safe-mode` is SECURE.
+|
+//={safe-mode-secure}
 
 |===
 // end::table[]

--- a/docs/_includes/attr-data.adoc
+++ b/docs/_includes/attr-data.adoc
@@ -2,58 +2,113 @@
 Included in:
 
 - user-manual: Built-in data attributes
+
+Changes:
+Added an example/notes column; 
+deleted doctitle because it is documented elsewhere; 
+added basebackend, filetype and outdir;
+consistently use 'document' for the input file and 'output file' for the output.
 ////
 
-Asciidoctor includes numerous intrinsic attributes that are assigned values when the document is rendered.
-The values of these built-in data attributes are derived from how the document is processed and when and where is it processed.
+Asciidoctor includes numerous attributes that are assigned values when the document is rendered.
+The values of these attributes are derived from how the document is processed and when and where is it processed.
 These attributes can be referenced anywhere in the document.
 
 // tag::table[]
-.Built-in data attributes
-[width="70%",cols="1m,3"]
+.Document attributes - runtime information
+[cols="1m,3a,1m"]
 |===
-|Attribute |Description
+|Attribute |Description |Example
 
-|asciidoctor
-|Calls the processor
+|asciidoctor 
+|Defined if the current processor is Asciidoctor.
+//|{asciidoctor}
+|(Empty string)
 
-|asciidoctor-version
-|Version of the processor
+|asciidoctor-version 
+|Version of the processor.
+//|Example: {asciidoctor-version}
+|1.5.2
 
 |backend
-|Backend used to render document
+|Backend used to create the output file.
+//|Example: {backend}
+|html5
+
+|basebackend
+|`html` or `docbook`.
+//|Example: {basebackend}
+|html
 
 |docdate
-|Last modified date
+|Last modified date of the document. [1]
+|2015-01-04
 
 |docdatetime
-|Last modified date and time
+|Last modified date and time of the document. [1]
+//|Example: {docdatetime}
+|2015-01-04 19:26:06 GMT+0000
 
-|docdir
-|Full path of the document directory
+|docdir 
+|Full path of the directory containing the document
+//|Example: {docdir}
+|home/projects/bike/userguide
 
-|docfile
-|Full path of the document file
+|docfile 
+|Full path of the document
+//|Example: {docfile}
+|home/projects/bike/userguide/master.adoc
 
 |docname
-|Basename of the document file (no directory or file extension)
+|Name of the input document without path or extension
+//|Example: {docname}
+|master
 
 |doctime
-|Last modified time
+|Last modified time. [1] 
+//|Example: {doctime}
+|19:26:06 GMT+0000
 
-|doctitle
-|The title of the document
+// This isn't a document attribute, it is a header attribute and is already in <<header-summary>>
+// |doctitle
+// |The title of the document
+// |
 
 |doctype
-|Document's doctype (e.g., article)
+|Document’s doctype-article, manpage or book.
+|article
 
-|localdate
-|Local date when rendered
+|encoding 
+|Encoding of the input and output files
+|UTF-8
 
-|localdatetime
-|Local date and time when rendered
+|filetype 
+|Extension of the output file name
+//|Example: {filetype}
+|html
+
+|localdate 
+|Date when rendered 
+//|Example: {localdate}
+|2016-02-17
+
+|localdatetime 
+|Date and time when rendered 
+//|Example: {localdatetime}
+|2016-02-17 19:31:05 GMT+0000
 
 |localtime
-|Local time when rendered
+|Time when rendered 
+//|Example: {localtime}
+|19:31:05 GMT+0000
+
+|outdir 
+|Full path of the output directory
+//|Example: {outdir}
+|home/projects/bike/dist
+
 |===
 // end::table[]
+
+[1] Does not check included files, so use with care.
+

--- a/docs/_includes/attr-data.adoc
+++ b/docs/_includes/attr-data.adoc
@@ -2,22 +2,15 @@
 Included in:
 
 - user-manual: Built-in data attributes
-
-Changes:
-Added an example/notes column; 
-deleted doctitle because it is documented elsewhere; 
-added basebackend, filetype and outdir;
-consistently use 'document' for the input file and 'output file' for the output.
-added safe-mode stuff
 ////
 
-Asciidoctor includes numerous attributes that are assigned values when the document is rendered.
-The values of these attributes are derived from how the document is processed and when and where is it processed.
+Asciidoctor includes numerous attributes that get assigned values when the document is converted (termed "intrinsic attributes").
+The values of these intrinsic attributes are derived from how, when and where the document is processed (in other words, its runtime environment).
 These attributes can be referenced anywhere in the document.
 
 // tag::table[]
-.Document attributes - runtime information
-[cols="1m,3a,1m"]
+.Intrinsic document attributes related to runtime information
+[cols="1m,3a,1m",width="80%"]
 |===
 |Attribute |Description |Example
 
@@ -37,7 +30,7 @@ These attributes can be referenced anywhere in the document.
 |html5
 
 |basebackend
-|`html` or `docbook`.
+|The backend value minus any trailing numbers. E.g. if the backend is `docbook5`, basebackend is `docbook`.
 //|Example: {basebackend}
 |html
 
@@ -51,60 +44,51 @@ These attributes can be referenced anywhere in the document.
 |2015-01-04 19:26:06 GMT+0000
 
 |docdir 
-|Full path of the directory containing the document
+|Full path of the directory containing the document.
 //|Example: {docdir}
-|home/projects/bike/userguide
+|/home/user/docs
 
 |docfile 
-|Full path of the document
+|Full path of the document.
 //|Example: {docfile}
-|home/projects/bike/userguide/master.adoc
+|/home/user/docs/userguide.adoc
 
 |docname
-|Name of the input document without path or extension
+|Name of the input document without path or extension.
 //|Example: {docname}
-|master
+|userguide
 
 |doctime
 |Last modified time. [1] 
 //|Example: {doctime}
 |19:26:06 GMT+0000
 
-// This isn't a document attribute, it is a header attribute and is already in <<header-summary>>
-// |doctitle
-// |The title of the document
-// |
-
 |doctype
-|Document’s doctype-article, manpage or book.
+|Document type (article, book or manpage.)
 |article
 
-|encoding 
-|Encoding of the input and output files.
-|UTF-8
-
 |filetype 
-|Extension of the output file name
+|Extension of the output file name.
 //|Example: {filetype}
 |html
 
 |localdate 
-|Date when rendered 
+|Date when converted.
 //|Example: {localdate}
 |2016-02-17
 
 |localdatetime 
-|Date and time when rendered 
+|Date and time when converted. 
 //|Example: {localdatetime}
 |2016-02-17 19:31:05 GMT+0000
 
 |localtime
-|Time when rendered 
+|Time when converted.
 //|Example: {localtime}
 |19:31:05 GMT+0000
 
 |outdir 
-|Full path of the output directory
+|Full path of the output directory.
 //|Example: {outdir}
 |home/projects/bike/dist
 

--- a/docs/_includes/attr-data.adoc
+++ b/docs/_includes/attr-data.adoc
@@ -90,7 +90,7 @@ These attributes can be referenced anywhere in the document.
 |outdir 
 |Full path of the output directory.
 //|Example: {outdir}
-|home/projects/bike/dist
+|home/user/docs/dist
 
 |safe-mode-level
 //={safe-mode-level}
@@ -118,6 +118,11 @@ These attributes can be referenced anywhere in the document.
 |Defined if `safe-mode` is SECURE.
 |
 //={safe-mode-secure}
+
+|user-home
+|home directory of the current user.
+|If the safe mode is server or greater it resolves to ".."
+|
 
 |===
 // end::table[]


### PR DESCRIPTION
Improve existing table first:
Added an example/notes column;
deleted doctitle because it is documented elsewhere;
added basebackend, filetype and outdir;
consistently use 'document' for the input file and 'output file' for the output.