### PR TITLE
Fix typo in block.adoc

### DIFF
--- a/docs/_includes/block.adoc
+++ b/docs/_includes/block.adoc
@@ -94,7 +94,7 @@ If you want the closing delimiter to be matched, it must be the same length as t
 
 ----
 ****
-valid example block
+valid sidebar block
 ****
 ----
 


### PR DESCRIPTION
It looks like the intended statement was "invalid sidebar block" as the block uses the * character.