### PR TITLE
Note use of font icons for non-selectable callouts

### DIFF
--- a/docs/_includes/callout-xml.adoc
+++ b/docs/_includes/callout-xml.adoc
@@ -20,5 +20,6 @@ Here's how it looks when rendered:
 include::ex-callout.adoc[tags=source-xml]
 ====
 
-Notice the comment has been replaced with a circled number that cannot be selected.
+Notice the comment has been replaced with a circled number that cannot be selected (if not using font icons it will be
+rendered differently and selectable).
 Now both you and the reader can copy and paste XML source code containing callouts without worrying about errors.


### PR DESCRIPTION
Note that use of font icons is required for XML callouts to ensure that they will not be selectable and provide the rendering described in the doc.

The use of font icons is covered in the next section of the documentation, and this led me to believe it wasn't necessary to achieve the rendering described (but that font icons were an alternative mechanism of achieving the same rendering). Admittedly this confusion largely arose because I'm a complete newbie but for me at least the documentation appeared to imply that font icons weren't a requirement to achieve the "light number in dark circle" rendering for callouts, so I believe other newbies might make a similar mistake. Therefore I've suggested a tiny clarification to the documentation on XML callouts. 
