### PR TITLE
Fixed result of listing block example showing wrong result.

### DIFF
--- a/docs/_includes/listing.adoc
+++ b/docs/_includes/listing.adoc
@@ -58,7 +58,7 @@ include::ex-src.adoc[tags=src-base]
 
 .Result: Listing block with the source attribute set
 ====
-include::ex-listing.adoc[tags=bl]
+include::ex-src.adoc[tags=src-base]
 ====
 
 Detailed instructions for using the source and source-highlighter attributes are provided in the <<user-manual#source-code-blocks,source code blocks>> section.


### PR DESCRIPTION
See http://asciidoctor.org/docs/user-manual/#listing-blocks, example 3 for the erroneous result.