### PR TITLE
Fix broken link to Neo4j manual

### DIFF
--- a/docs/what-is-asciidoc.adoc
+++ b/docs/what-is-asciidoc.adoc
@@ -260,7 +260,7 @@ AsciiDoc is not as widely adopted as Markdown, but it's used in some pretty seri
 * http://docs.jboss.org/cdi/spec/1.1/cdi-spec.html[Specification] (https://github.com/cdi-spec/cdi/tree/master/spec[AsciiDoc source])
 * http://www.cdi-spec.org[Website] (https://github.com/cdi-spec/cdi-spec.org[AsciiDoc source])
 - http://golo-lang.org/documentation/next[Golo Programming Language Guide] (https://github.com/golo-lang/golo-lang/tree/master/doc[AsciiDoc source])
-- http://docs.neo4j.org/chunked/stable[Neo4j graph database project] (https://github.com/neo4j/neo4j/tree/master/manual/src[AsciiDoc source])
+- http://docs.neo4j.org/chunked/stable[Neo4j graph database project] (https://github.com/neo4j/neo4j-documentation/tree/3.1/manual[AsciiDoc source])
 - http://www.modrails.com/documentation/Users%20guide%20Apache.html[Phusion Passenger Users Guides] (https://github.com/FooBarWidget/passenger/tree/master/doc[AsciiDoc source])
 - https://www.kernel.org/pub/software/scm/git/docs/user-manual.html[Git user manual] (https://github.com/git/git/tree/master/Documentation[AsciiDoc source])
 - http://enterprisewebbook.com[Enterprise Web Development: From Desktop to Mobile] (https://github.com/Farata/EnterpriseWebBook[AsciiDoc source])


### PR DESCRIPTION
neo4j/neo4j#8235 moved the manual out of the tree, presumably to
maintain it in the separate neo4j/neo4j-documentation project. That
project has no `master` branch so point to the `3.1` branch instead.