### PR TITLE
Resolves #558 element attributes

### DIFF
--- a/docs/_includes/attr-element.adoc
+++ b/docs/_includes/attr-element.adoc
@@ -4,7 +4,151 @@ Included in:
 - user-manual: Attributes: Setting attributes on an element
 ////
 
+
+////
+
+...there's still some confusion between document attributes and element attributes. We should make this distinction very clear.
+
+In general, Asciidoctor uses attributes as a way to store and deliver metadata. Document attributes are available everywhere and are used to control behavior of the document (they have a broad scope). Element attributes are specifically for controlling an individual element and are scoped to that element. Unlike document attributes, element attributes cannot be referenced using an attribute reference (though, that could change in UniDoc).
+
+Element here refers to a node or a directive. A node is a paragraph, a delimited block, a block macro, an inline macro or a span of formatted text. (maybe that needs to go in the glossary).
+////
+
+// tag::revised[]
+
+
+Element attributes are defined in "attribute lists" between square brackets, and apply only to the immediately following "element",
+where an "element" can be:
+
+* a paragraph
+* a delimited block
+* a block macro
+* an inline macro
+* a span of formatted text
+
+The syntax for setting element attributes is different from that for document attributes, and there is shorthand available for the most common attributes.
+
+For example, in:
+
+----
+[WARNING]
+Keep hands away from moving machinery
+----
+
+* The attribute list contains a single attribute `style` (a "positional attribute"), which has the value `WARNING`. 
+
+* The element that it applies to is the single paragraph "Keep hands away from moving machinery".
+
+Element attributes override document attributes, so that if the example had been preceded by 
+
+----
+:style: quote
+----
+
+The style of the paragraph would still have been WARNING, 
+and the value of the `style` attribute before and after the paragraph would still be `quote`.
+
+==== Element attribute syntax
+
+Element attributes can be set using:
+
+* named attributes
+
+* shorthand
+
+* positional attributes
+
+Named attributes are simple name-value pairs:
+
+----
+[width="100m"]
+----
+
+The quotes are not necessary for simple strings.
+To unset an attribute (because there is a document attribute already set that you do not want), set its value to `none`.
+
+Because they are used so often, shorthand exists for setting the attributes `role` (.), `options` (%), and `id` (#), so
+
+----
+[#dogs.summary.incremental%unbreakable%header]
+----
+
+is exactly the same as 
+
+----
+[id="dogs",role="summary,incremental",options="unbreakable,header"]
+----
+
+Finally, if you do not give it any other clues, the element will assign attributes based on the position of the value in the list (a "positional attribute"), for example:
+
+.Positional attribute examples
+|====
+|Element |Position 1 |Position 2 |Position 3
+
+|Blocks
+|style
+|-
+|-
+
+
+|Block macros
+|style
+|Depends on the macro
+|Depends on the macro
+
+|image:: macro
+|alt text
+|width
+|height
+
+|Quotation block
+|style (quote or verse)
+|attribution
+|citation title and information
+
+|Inline quoted text
+|role
+|-
+|-
+
+|====
+
+Positional, shorthand and named attributes can be combined.
+For example:
+
+----
+[horizontal#eggs.properties%step%big, width="200mm"]
+----
+
+when applied to a block is interpreted as
+
+----
+[style="horizontal", id="eggs", role="properties", options="step,big", width="200mm"]
+----
+
+Inline quoted text includes text between formatting marks (*, _, `), for example
+
+----
+[rolename]`monospace text`
+----
+
+// Is this worth saying? What would the user assume if we didnt say it?
+
+The inline attribute list can be escaped using a backslash. The text will still be formatted, but the attribute list will be unescaped and output verbatim:
+
+----
+\[role]*bold*
+----
+
+\[role]*bold*
+
+
+// end::revised[]
+
 // tag::intro[]
+
+Unlike document attributes, element attributes cannot be referenced using an attribute reference 
+
 An attribute list can apply to blocks, inline quotes text, and macros.
 The attributes and their values contained in the list will take precedence over attribute entries.
 
@@ -35,3 +179,4 @@ Named attributes are assigned a value with an `=` in an attribute list.
 
 To undefine a named attribute, set the value to `none`.
 // end::name[]
+

--- a/docs/_includes/attr-style.adoc
+++ b/docs/_includes/attr-style.adoc
@@ -5,10 +5,11 @@ Included in:
 ////
 
 // tag::intro[]
-The style attribute is the first positional attribute in an attribute list.
-It specifies a predefined set of characteristics that should apply to a block element or macro.
+// Would this not be better moved to paragraph?
 
-For example, a paragraph block can be assigned one of the following built-in style attributes:
+//The style attribute is the first positional attribute in an attribute list.
+The style attribute specifies a predefined set of characteristics that should apply to a block element or macro.
+For example, a paragraph block can be assigned one of the following built-in styles:
 
 * normal (default, so does not need to be set)
 * literal
@@ -31,12 +32,16 @@ For example, a paragraph block can be assigned one of the following built-in sty
 
 ==== Id
 // tag::id[]
+
+// usage 2 needs an example
+
 The id attribute specifies a unique name for an element.
 That name can only be used once in a document.
 
 An id has two purposes:
 
-. to provide an internal link or cross reference anchor for the element
+. to provide an internal link or cross reference anchor for the element (an anchor in html, or an xml:id in docbook)
+
 . to reference a style or script used by the output processor
 // end::id[]
 
@@ -90,3 +95,27 @@ The id (`#`) shorthand can be used on inline quoted text.
 [[free_the_world]]*free the world*
 ----
 ////
+
+// tag::role[]
+
+// ==== Role
+
+Role is a general-purpose attribute that is mainly used to pass formatting hints to the backends.
+For example, `[role=horizontal]` on a definition list suggests to the backend that the list terms are all quite short, and the list can be presented in a compact format.
+
+In html output for inline content, `role` becomes `class`:
+
+----
+[rolename]`monospace text`
+----
+
+----
+<code class="rolename">monospace text</code>
+----
+
+In docbook output, role is output directly on the docbook element, where it can be processed by the docbook stylesheets.
+
+role can have multiple values, which are concatenated into a comma separated value list on output.
+
+// end::role[]
+

--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -318,15 +318,17 @@ include::{includedir}/attr-doc.adoc[]
 
 === Setting Attributes on an Element
 
-include::{includedir}/attr-element.adoc[tags=intro]
+//include::{includedir}/attr-element.adoc[tags=intro]
 
-==== Positional Attribute
+include::{includedir}/attr-element.adoc[tags=revised]
 
-include::{includedir}/attr-element.adoc[tags=pos]
+//==== Positional Attribute
 
-==== Named Attribute
+//include::{includedir}/attr-element.adoc[tags=pos]
 
-include::{includedir}/attr-element.adoc[tags=name]
+//==== Named Attribute
+
+//include::{includedir}/attr-element.adoc[tags=name]
 
 ==== Style
 
@@ -336,20 +338,19 @@ include::{includedir}/attr-style.adoc[tags=intro]
 
 include::{includedir}/attr-style.adoc[tags=id]
 
-===== Block Assignment
+//===== Block Assignment
 
-include::{includedir}/attr-style.adoc[tags=bl]
+//include::{includedir}/attr-style.adoc[tags=bl]
 
-===== Inline Assignment
+//===== Inline Assignment
 
-include::{includedir}/attr-style.adoc[tags=in]
+// include::{includedir}/attr-style.adoc[tags=in]
 
 ==== Role
 
-NOTE: Section introduction pending
+include::{includedir}/attr-style.adoc[tags=role]
 
-An element can be assigned numerous roles.
-
+////
 ===== Block Assignment
 
 In an attribute list, there are two ways to assign a role attribute to a block element.
@@ -386,7 +387,9 @@ To specify multiple roles using the shorthand syntax, separate them by dots.
 * Review 1
 * Review 2
 ----
+////
 
+////
 ===== Inline Assignment
 
 The role (`.`) shorthand can be used on inline quoted text.
@@ -431,12 +434,18 @@ which produces:
 <a id="idname"></a><code class="rolename">monospace text</code>
 ```
 
+////
+
 ==== Options
 
 The options attribute is a versatile named attribute that can contain a comma separated list of values.
 
+Its uses are similar to role, but more often gives hints to the processor as to how to treat the element.
+For example [`options=header`] on a table indicates that the first row of data contains table headings.
+
 It can also be defined globally with an attribute entry.
 
+////
 ===== Block Assignment
 
 In an attribute list, there are three ways to assign an options attribute to a block element.
@@ -482,6 +491,7 @@ property 2:: does different stuff
 property 1:: does stuff
 property 2:: does different stuff
 ----
+////
 
 === Assigning Document Variables Inline
 


### PR DESCRIPTION
Resolves #558 element attributes

The brief was to clarify the difference between document and element attributes, but I got carried away.
Mainly I have tried to separate the syntax of role, options and id  from the purpose of the attributes.
