### PR TITLE
Remove warning about extensions for v0.1.4

### DIFF
--- a/docs/_includes/exten-intro.adoc
+++ b/docs/_includes/exten-intro.adoc
@@ -15,15 +15,3 @@ Extensions in AsciiDoc (technically called filters) have a number of problems:
 
 The goal for Asciidoctor has always been to allow extensions to be written using the full power of a programming language (whether it be Ruby, Java, Groovy or JavaScript), similar to what we've done with the backend (rendering) mechanism.
 That way, you don't have to shave yaks to get the functionality you want, and you can distribute the extension using defacto-standard packaging mechanisms (like RubyGems or JARs).
-
-The extension API is available as a technology preview in Asciidoctor 0.1.4.
-
-.Technology Preview
-[WARNING]
-====
-The extension API should be considered *experimental* and *subject to change*.
-This technology preview is intended for developers interested in playing around with it and helping to mature the design.
-
-If you need the capabilities that extensions provide now, don't be afraid to jump on board.
-Just keep in mind that you may need to rework parts of your extensions when you upgrade Asciidoctor.
-====


### PR DESCRIPTION
The reference to the status of Extensions in v0.1.4 is probably outdated. Any new information about extensions and their use should be added, and other references throughout the user manual should probably also be updated. Those are in example text, so they would not be substantive changes.