### PR TITLE
Fix the table example with rolename

### DIFF
--- a/docs/_includes/ex-table.adoc
+++ b/docs/_includes/ex-table.adoc
@@ -27,6 +27,29 @@ Examples for table sections
 |===
 // end::base-alt[]
 
+// tag::base-rolename[]
+[.rolename]
+|===
+
+| Cell in column 1, row 1 | Cell in column 2, row 1 | Cell in column 3, row 1
+
+| Cell in column 1, row 2 | Cell in column 2, row 2 | Cell in column 3, row 2
+
+|===
+// end::base-rolename[]
+
+// tag::base[]
+|===
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+|Cell in column 3, row 1
+
+|Cell in column 1, row 2 
+|Cell in column 2, row 2 
+|Cell in column 3, row 2
+|===
+// end::base[]
+
 // tag::cell1[]
 |===
 
@@ -114,18 +137,6 @@ Examples for table sections
 
 |===
 // end::2col[]
-
-// tag::base[]
-|===
-|Cell in column 1, row 1
-|Cell in column 2, row 1
-|Cell in column 3, row 1
-
-|Cell in column 1, row 2
-|Cell in column 2, row 2
-|Cell in column 3, row 2
-|===
-// end::base[]
 
 // tag::base-xtr[]
 |===

--- a/docs/_includes/table.adoc
+++ b/docs/_includes/table.adoc
@@ -35,8 +35,7 @@ The preferred shorthand for assigning the role attribute is to put the role name
 
 [source]
 ----
-[.rolename]
-include::ex-table.adoc[tags=base]
+include::ex-table.adoc[tags=base-rolename]
 ----
 
 Leading and trailing spaces around cell content is stripped and, therefore, don't affect the table's layout when rendered.


### PR DESCRIPTION
As [discussed](http://discuss.asciidoctor.org/Table-amp-column-example-from-the-doc-is-not-working-td5129.html) on the mailing list, I have fixed the example "Table with rolename".

Because at this point of the docs, the `cols` attribute is not explained, I have changed the example with the rows defined on the same line (as in the previous example).

In `ex-table.adoc` file, I have moved the `tag::base[]` example (near to the other `base` examples). This snippet is used a lot in the `table-col.adoc` File.
