### PR TITLE
README: Use SVG build badge icon

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= asciidoctor.org image:https://secure.travis-ci.org/asciidoctor/asciidoctor.org.png?branch=master["Build Status", link="https://travis-ci.org/asciidoctor/asciidoctor.org"]
+= asciidoctor.org image:https://secure.travis-ci.org/asciidoctor/asciidoctor.org.svg?branch=master["Build Status", link="https://travis-ci.org/asciidoctor/asciidoctor.org"]
 
 Project site for http://asciidoctor.org[Asciidoctor], composed in AsciiDoc, styled by Foundation, baked with Awestruct and published by Travis CI.
 


### PR DESCRIPTION
This PR changes the link to the image used by the build status badge in the README to use shiny SVG.

_Thank you for this project!_