### PR TITLE
Add safe mode restriction note to documentation of linkcss

### DIFF
--- a/docs/_includes/html-styles.adoc
+++ b/docs/_includes/html-styles.adoc
@@ -31,6 +31,8 @@ Additionally, you can inspect mysample.html in your browser and see `<link rel="
 image::mysample-link.png[]
 ====
 
+Keep in mind that in order to use the linkcss attribute, the safe mode level needs to be at least **SAFE**.
+
 If you don't want any styles applied to the HTML output of your document, unset the `stylesheet` attribute.
 
  $ asciidoctor -a stylesheet! mysample.adoc


### PR DESCRIPTION
When learning how to use asciidoctor, I had no idea that the safe mode SAFE is necessary to use the attribute linkcss. So I add it here to clarify for future users.
IMO, all attributes with such restrictions should clarify in their explanations.