### PR TITLE
fix uri-image-attrs link

### DIFF
--- a/docs/asciidoc-syntax-quick-reference.adoc
+++ b/docs/asciidoc-syntax-quick-reference.adoc
@@ -30,7 +30,7 @@ endif::[]
 :uri-marker: {user}/#custom-markers
 :uri-list-num: {user}/#numbering-styles
 :uri-imagesdir: {user}/#set-the-images-directory
-:uri-image-attrs: {user}/#put-images-in-their-place
+:uri-image-attrs: {user}/#putting-images-in-their-place
 :uri-toc: {user}/#user-toc
 :uri-para: {user}/#paragraph
 :uri-literal: {user}/#literal-text-and-blocks


### PR DESCRIPTION
The link in the TIP from [**Inline image with positioning role**](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#images) don't work correctly.