### PR TITLE
README: Linked dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = asciidoctor.org image:https://secure.travis-ci.org/asciidoctor/asciidoctor.org.svg?branch=master["Build Status", link="https://travis-ci.org/asciidoctor/asciidoctor.org"]
 
-Project site for http://asciidoctor.org[Asciidoctor], composed in AsciiDoc, styled by Foundation, baked with Awestruct and published by Travis CI.
+Project site for http://asciidoctor.org[Asciidoctor], composed in AsciiDoc, styled by http://foundation.zurb.com/sites/docs/v/5.5.3/[Foundation 5], baked with http://awestruct.org/[\Awestruct] and published by https://travis-ci.org/[Travis CI].
 
 For instructions on how to install Awestruct and its dependencies, refer to the section xref:install-awestruct[Install Awestruct] below.
 


### PR DESCRIPTION
For Foundation it might be imprtat to note it is the old version.

The Travis CI link is optional as the is a build batch next to it. I refrained from using {:Awestruct} logo text, but that would be another possible addition.