### PR TITLE
README: link to external frameworks used

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,8 @@
 = asciidoctor.org image:https://secure.travis-ci.org/asciidoctor/asciidoctor.org.svg?branch=master["Build Status", link="https://travis-ci.org/asciidoctor/asciidoctor.org"]
 
-Project site for http://asciidoctor.org[Asciidoctor], composed in AsciiDoc, styled by Foundation, baked with Awestruct and published by Travis CI.
+Project site for http://asciidoctor.org[Asciidoctor], composed in AsciiDoc,
+styled by  http://foundation.zurb.com/sites/docs/v/4.3.2/[Foundation 4], baked with http://awestruct.org/[Awestruct]
+and published by https://travis-ci.org/[Travis CI].
 
 For instructions on how to install Awestruct and its dependencies, refer to the section xref:install-awestruct[Install Awestruct] below.
 


### PR DESCRIPTION
Make it explicite that older Awestruc is used.