### PR TITLE
Update revnumber to include the latest readme

### DIFF
--- a/docs/asciidoctor-diagram.adoc
+++ b/docs/asciidoctor-diagram.adoc
@@ -1,7 +1,7 @@
 // NOTE include file is not resolved when reading the header only, hence the extra attributes
 :doctitle: Asciidoctor Diagram
 :uri-project-repo: https://github.com/asciidoctor/asciidoctor-diagram
-:revnumber: 1.5.0
+:revnumber: 1.5.4
 :gitref: v{revnumber}
 :page-layout: docs
 :keywords: Asciidoctor Diagram, AsciiDoc, Asciidoctor, diagrams, PlantUML, Graphviz, ditaa, UML, sequence diagram, use case diagram, class diagram, activity diagram, component diagram, state diagram, object diagram, ASCII art, SVG


### PR DESCRIPTION
Update readme to include the latest readme for asciidoctor-diagram. I was missing the diagram attributes table recently and think it should be accessible from a more popular location ;-)