### PR TITLE
Spelling/grammar: "An optional revision, a date and an option remark"

### DIFF
--- a/docs/asciidoc-writers-guide.adoc
+++ b/docs/asciidoc-writers-guide.adoc
@@ -472,7 +472,7 @@ Let's see how to add additional information to the header, including an author.
 There are two optional lines of text you can add immediately below the document title for defining common document attributes:
 
 Line 1:: Author name and an optional e-mail address
-Line 2:: An optional revision, a date and an option remark
+Line 2:: An optional revision, a date and an optional remark
 
 Let's add these lines to our document:
 


### PR DESCRIPTION
Correct `An optional revision, a date and an option remark` to `An optional revision, a date and an optional remark`, option -> optional.