### PR TITLE
Update subs-prevent.adoc

### DIFF
--- a/docs/_includes/subs-prevent.adoc
+++ b/docs/_includes/subs-prevent.adoc
@@ -20,4 +20,4 @@ include::ex-subs.adoc[tag=slash]
 ----
 
 // end::backslash[]
-You can also prevent substitutions with <<user-manual#passthru,macro and block passthroughs>>.
+You can also prevent substitutions with <<user-manual#passthroughs,macro and block passthroughs>>.


### PR DESCRIPTION
The link at the very end of this section is dead: the #id in the link needs respelling: #passthru --> #passthroughs --so as to link successfully to Sec. 43 (according to the website-version numbering), "Passthroughs". Fixes #715 