### PR TITLE
Update header-title.adoc

### DIFF
--- a/docs/_includes/header-title.adoc
+++ b/docs/_includes/header-title.adoc
@@ -79,7 +79,7 @@ Instead of using a colon followed by a space as the separator characters between
 
 .Document with a subtitle using a custom separator
 ----
-include::ex-header-title.adoc[tag=sub-2]
+include::ex-header-title.adoc[tag=sub-3]
 ----
 
 Note that a space is always appended to the value of the `title-separator` (making the default value of the `title-separator` effectively a single colon).


### PR DESCRIPTION
The listing entitled "Document with a subtitle using a custom separator" INCLUDEs the same tagged region (sub-2) as does the previous listing (entitled "Document with a subtitle and multiple colons"). Apparently this is just a typo, and it was intended to point rather to the subsequent tagged region (sub-3).