### PR TITLE
Linking to asciidoctor-reveal.js v1.0.4

### DIFF
--- a/docs/asciidoctor-revealjs.adoc
+++ b/docs/asciidoctor-revealjs.adoc
@@ -1,6 +1,6 @@
 // NOTE include file is not resolved when reading the header only, hence the extra attributes
 :doctitle: Asciidoctor Reveal.js
-:revnumber: 1.0.1
+:revnumber: 1.0.4
 :gitref: v{revnumber}
 :page-layout: docs
 :keywords: Asciidoctor Reveal.js, AsciiDoc, Asciidoctor, reveal.js, slides


### PR DESCRIPTION
I forgot to do that in the past releases. I'm adding this to my release documentation.