### PR TITLE
Update formatting-marks.adoc

### DIFF
--- a/docs/_includes/formatting-marks.adoc
+++ b/docs/_includes/formatting-marks.adoc
@@ -199,7 +199,7 @@ It means to format TEXT as monospace, but don't interpolate formatting marks or 
 It's roughly equivalent to Markdown's backticks.
 Since AsciiDoc offers more advanced formatting, the double enclosure is necessary.
 
-The more brute-force solution to the inline passthrough approach is to use the `+pass:c[]+` macro, which is a more verbose (and flexible) version of the plus formatting marks.
+The more brute-force solution to the inline passthrough approach is to use the pass:q[`pass:c[\]`] macro, which is a more verbose (and flexible) version of the plus formatting marks.
 
 ----
 The pass:c[__kernel] qualifier can be used with the pass:c[__attribute__] keyword...
@@ -208,7 +208,7 @@ The pass:c[__kernel] qualifier can be used with the pass:c[__attribute__] keywor
 ----
 
 As you can see, however, the macro is not quite as elegant or concise.
-In case you're wondering, the c in the target slot of the `+pass:[]+` macro applies output escaping for HTML.
+In case you're wondering, the c in the target slot of the pass:q[`pass:c[\]`] macro applies output escaping for HTML.
 Though not always required, it's best to include this flag so you don't forget to when it is needed.
 
 Backslashes for escaping aren't very reliable in AsciiDoc.


### PR DESCRIPTION
Apply an attribute to `pass:[]`, not a passthrough.

Though it seems sensible on first blush, a passthrough will not permit a passthrough - to pass through (!). What's coming through instead is `<code></code>` . Though I don't know, I guess this is because within macros, macro-substitution takes place (sec. 40.5)...?

These are the only two places this exact AsciiDoc occurs within this file. I did find within the User-Doc HTML the `<code></code>` pattern in one other section - 46.2 - to where I'll now trot off and have a look :)