### PR TITLE
Apply style attribute to ++++ being taken as macro

### DIFF
--- a/docs/_includes/stem.adoc
+++ b/docs/_includes/stem.adoc
@@ -72,7 +72,7 @@ Block formulas are marked up by assigning the `stem` style to a delimited passth
 include::ex-stem.adoc[tag=bl-co]
 ----
 <1> Assign the stem style to the passthrough block.
-<2> A passthrough block is delimited by a line of four consecutive plus signs (`++++`).
+<2> A passthrough block is delimited by a line of four consecutive plus signs (`pass:[++++]`).
 
 The result is rendered beautifully in the browser thanks to MathJax!
 


### PR DESCRIPTION
Though it seems intuitive, putting `++++` inline in normal text doesn't work. What's coming through from it is `<code></code>`.

I'm guessing it is treated as a "single plus" passthrough macro, within another -- and, perhaps in keeping with sec. 40.5, the inner passthrough is processed (passing an empty value), and then the outer one (doing likewise!). 