### PR TITLE
Remove redundant escape '\'s in literal columns

### DIFF
--- a/docs/_includes/subs-symbol-repl.adoc
+++ b/docs/_includes/subs-symbol-repl.adoc
@@ -12,64 +12,64 @@ Included in:
 |Name |Syntax |Unicode Replacement |Rendered |Notes
 
 |Copyright
-|\(C)
-|\&#169;
+|(C)
+|&#169;
 |(C)
 |
 
 |Registered
-|\(R)
-|\&#174;
+|(R)
+|&#174;
 |(R)
 |
 
 |Trademark
-|\(TM)
-|\&#8482;
+|(TM)
+|&#8482;
 |(TM)
 |
 
 |Em dash
-|\--
-|\&#8212;
+|--
+|&#8212;
 |{empty}--{empty}
 |Only replaced if between two word characters, between a word character and a line boundary, or flanked by spaces.
 
 When flanked by space characters (e.g., `+a -- b+`), the normal spaces are replaced by thin spaces (\&#8201;).
 
 |ellipses
-|\...
-|\&#8230;
+|...
+|&#8230;
 |...
 |
 
 |right single arrow
-|\->
-|\&#8594;
+|->
+|&#8594;
 |->
 |
 
 |right double arrow
-|\=>
-|\&#8658;
+|=>
+|&#8658;
 |=>
 |
 
 |left single arrow
-|\<-
-|\&#8592;
+|<-
+|&#8592;
 |<-
 |
 
 |left double arrow
-|\<=
-|\&#8656;
+|<=
+|&#8656;
 |<=
 |
 
 |apostrophe
-|Sam\'s
-|Sam\&#8217;s
+|Sam's
+|Sam&#8217;s
 |Sam's
 |The vertical form apostrophe is replaced with the curved form apostrophe.
 |===


### PR DESCRIPTION
I don't see the point in having backslash escapes inside a literal column. 

I'm guessing that the escapes had already been entered, and later the author of the table decided to make columns 2 and 3 literal-format. But, the escapes "escaped" eviction (even tho they had become redundant).