### PR TITLE
Remove redundant \ escape in a literal-style block

### DIFF
--- a/docs/_includes/ex-manpage.adoc
+++ b/docs/_includes/ex-manpage.adoc
@@ -38,5 +38,5 @@ eve - analyzes an image to determine if it's a picture of a life form
 
 == COPYING
 
-Copyright \(C) 2008 {author}. +
+Copyright (C) 2008 {author}. +
 Free use of this software is granted under the terms of the MIT License.


### PR DESCRIPTION
I'm not sure how formatting is done in a man page -- I've written exactly zero of them.
However, I'm guessing that the literal styling this AsciiDoc source is shown in, makes that \ escape of the copyright symbol-code redundant.