### PR TITLE
Correct typo in cross-ref. to Passthroughs section

### DIFF
--- a/docs/_includes/text-quote-apos.adoc
+++ b/docs/_includes/text-quote-apos.adoc
@@ -43,7 +43,7 @@ include::ex-text.adoc[tag=apos]
 ====
 
 If you don't want an apostrophe that is bound by two characters to be rendered as curved, escape it by preceding it with a backslash (`{backslash}`).
-The <<user-manual#preventing-substitutions,preventing substitutions>> and <<user-manual#passthru,passthrough>> sections detail additional ways to prevent punctuation substitutions.
+The <<user-manual#preventing-substitutions,preventing substitutions>> and <<user-manual#passthroughs,passthrough>> sections detail additional ways to prevent punctuation substitutions.
 
 ----
 Olaf\'s desk ...


### PR DESCRIPTION
At the end of this section on Quotation Marks and Apostrophes (22.2 on the website), there is a link, broken, to the Passthroughs section (43 on the website). It's broken only because it has '#passthru', while the ID of sec. 43 is '#passthroughs'. A quick realignment of the spelling, and  we're "in business" ;)