### PR TITLE
Correct typo in cross-ref. to Passthroughs section

### DIFF
--- a/docs/_includes/subs-specchar.adoc
+++ b/docs/_includes/subs-specchar.adoc
@@ -13,7 +13,7 @@ The specialchars element searches for three characters (`<`, `>`, `&`) and repla
 * An ampersand, `&`, is replaced with the `\&amp;` character entity reference.
 
 By default, the special characters substitution occurs on all inline and block elements except for comments and certain passthroughs.
-The substitution of special characters can be controlled on blocks using the <<user-manual#applying-substitutions, subs attribute>> and on inline elements using the <<user-manual#passthru,passthrough macro>>.
+The substitution of special characters can be controlled on blocks using the <<user-manual#applying-substitutions, subs attribute>> and on inline elements using the <<user-manual#passthroughs,passthrough macro>>.
 
 [NOTE]
 ====


### PR DESCRIPTION
Towards the end of this section on Special Characters (40.1 on the website), there is a link, broken, to the Passthroughs section (43 on the website). It's broken only because it has '#passthru', while the ID of sec. 43 is '#passthroughs'. A quick realignment of the spelling, and  we're "in business" ;)