### PR TITLE
Emend "Attribute value" row in sec. 40.6 table

### DIFF
--- a/docs/_includes/subs-post.adoc
+++ b/docs/_includes/subs-post.adoc
@@ -11,7 +11,7 @@ The line break character, `{plus}`, is replaced when the `post_replacements` pro
 |===
 |Element | `post_replacements` substitution
 
-|Attribute value |{y}
+|Attribute value |{n}
 
 |Comment |{n}
 


### PR DESCRIPTION
The table in view is entitled, "Elements subject to post replacements text substitution". Its section, 40.6, is entitled, "Post Replacements". Please bear with me as I try to explain the problem as quickly as I can... I'm really just trying to check my understanding of how AsciiDoctor works (which, when it seems not to comport with something in the manual, concerns me!!).

So yes--I must admit, I'm a bit unsure of the exact semantics of this "Attribute value" row, in such tables (in Secs. 40.1-40.6). However, logic seems to constrain a reasonable interpreter thus: 

This row's presence here would make no sense, really, if the row intended to refer either to
1) "Named attributes" (which, according to Sec. 13.5.2, have their own substitution rules, dependent on use of single or double quotes); or to
2) Substitutions within the value that an attribute-reference has already expanded _into_ (after all, whether _that_ substitution would take place depends *not* on whether the value came from an attribute-reference expansion, but rather on what the order of substitutions might be, *post-attribute-ref-expansion*, at the point the attribute-reference occurs).

So, I'm inferring from all this that the row intends, rather, to refer to expansions, within an attribute's value, _at the place where the attribute was defined_. (*Please correct me*, if I'm wrong!)

Add that "fact" to one other I seem to "know", and the current population of this row becomes problematic (to me): This second "fact" is that my tests seem to show, concerning "replacement", "post replacement", and "quote" substitutions, that any of them _can_ happen within the attribute's value, _at the point where an attribute-ref has (already) expanded into that value_; *but*, such expansions can never happen within the attribute value _at the point where the attribute is being defined_. (It seems irrelevant to this, whether the attribute is defined in the doc header or defined later.)

I did all my tests on these expansions with the AsciiDoctor version (apparently 1.5.5-4) that is in the v.2.10.2 "asciidoc-preview" package for Atom. (I gathered this was its AsiiDoctor version, from scanning the package's CHANGELOG in Atom.)

OK--if my interpretation of the semantics were sound, and unless my tests (repeated several times) are tricking me, it would seem to follow that the row under discussion should have a cross (for NO), rather than a check-mark, in column 2. This conclusion seems corroborated by the fact that the corresponding rows in the corresponding tables about Replacements expansions (sec. 40.4) and Quotes (sec. 40.2), seemingly subject to the same interpretation-logic and giving me the same test-results, have crosses in that column.

Anybody follow, and agree with, my logic??
 
By the way, macro-substitution (sec. 40.5) is a horse of a rather different color: I've not been able to get *any* macro-substitution to work in an attribute value, whether at the point of definition or at the point of attribute-ref. However, all the more does it seem to follow, that the corresponding row in sec. 40.5's corresponding table should have a cross in column 2--but, it too has a check-mark. This may indicate that I'm totally off-track in my reasoning; or it may be that that table is actually subject to the same (or a stronger) argument and needs similarly emending. 
I guess that, strictly speaking, that one would be a discussion for a different PR ; but does anyone wish to comment on it in this PR?
Oh, and one other discussion for a different PR ;) Can anybody think of a way to (re)name these table rows, that would clarify better their exact meaning?
