### PR TITLE
Add crucial, missing sentence(s) to Sec. 13.4.1

### DIFF
--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -87,16 +87,16 @@ Attribute entries can not::
 
 ==== Substitutions in an attribute entry
 
-<<user-manual#subs,Text substitution elements>> replace characters, markup, attribute references, and macros with converter specific styles and values.
 When Asciidoctor processes a document it uses a set of six text substitution elements.
+<<user-manual#subs,Text substitution elements>> replace characters, markup, attribute references, and macros with converter-specific styles and values.
 
-In elements belonging to the header substitution group, only <<user-manual#special-characters,special characters>> and <<user-manual#attributes-2,attribute references>> are replaced.
-The `header` substitution group is applied to the header of your document.
-It is applied also to attribute entries' values, whether those entries are in the header or elsewhere in the document.
+The header substitution group replaces <<user-manual#special-characters,special characters>> and <<user-manual#attributes-2,attribute references>> in text to which it is applied.
+The header substitution group is applied to metadata lines (author and revision information) in the document header.
+This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 
-However, if you require other substitutions to be applied to an attribute's value, use the <<user-manual#pass-macros,inline pass macro>>.
-This macro has special meaning in an attribute entry.
-It allows the substitutions to be applied at the time the attribute is defined.
+If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
+In order for the inline macro to be processed, it must completely enclose the attribute value.
+It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
 
 The inline pass macro accepts a list of substitutions in the `target` slot.
 In the next example, we'll apply the <<user-manual#quotes,quotes substitution>> to an attribute entry's value.

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -87,10 +87,12 @@ Attribute entries can not::
 
 ==== Substitutions in an attribute entry
 
-The `header` substitution group is applied to the header of your document.
 <<user-manual#subs,Text substitution elements>> replace characters, markup, attribute references, and macros with converter specific styles and values.
 When Asciidoctor processes a document it uses a set of six text substitution elements.
-In the header, only <<user-manual#special-characters,special characters>> and <<user-manual#attributes-2,attribute references>> are replaced.
+
+In elements belonging to the header substitution group, only <<user-manual#special-characters,special characters>> and <<user-manual#attributes-2,attribute references>> are replaced.
+The `header` substitution group is applied to the header of your document.
+It is applied also to attribute entries' values, whether those entries are in the header or elsewhere in the document.
 
 However, if you require other substitutions to be applied to an attribute's value, use the <<user-manual#pass-macros,inline pass macro>>.
 This macro has special meaning in an attribute entry.


### PR DESCRIPTION
The section challenged the reader by, first, starting with a paragraph that's only about the "header" substitution group (no mention of attribute entries, which is what the section is allegedly about). Then it follows this paragraph with several that speak only of attribute-entry values (no mention of header substitution!). In vain does the reader scan the text for a link connecting paragraph 1 with the rest.

The minimal missing connection is the one in this text, which we have added to paragraph 2: [The header substitution group] "is applied also to attribute entries' values, whether those entries are in the header or elsewhere in the document".

Our argument for this addition is:
1) At least in our experience and tests of AsciiDoctor, attribute-entries' values do indeed behave as if attribute entries belong to the "header" substitution group described in this section;
2) Mentioning that fact, early in this section, is the only thing that would make the material that was already here hang together logically.
3) This point we suggest be made explicit is in fact the only main point that this section could have conceivably been intended to make. It's therefore arguably the sentence most important to make explicit.

I have taken this opportunity also to move two of paragraph 1's sentences into a new paragraph 2, where I've placed this new, "crucial" sentence. This restructuring intends to improve the topical flow within these paragraphs.