### PR TITLE
Emend "Header" rows, Elements tables, secs. 40.5-6

### DIFF
--- a/docs/_includes/subs-macro.adoc
+++ b/docs/_includes/subs-macro.adoc
@@ -20,7 +20,7 @@ The macros substitution replaces a macro's content with the appropriate built-in
 
 |Fenced |{n}
 
-|Header |{y}
+|Header |{n}
 
 |Literal |{n}
 

--- a/docs/_includes/subs-post.adoc
+++ b/docs/_includes/subs-post.adoc
@@ -19,7 +19,7 @@ The line break character, `{plus}`, is replaced when the `post_replacements` pro
 
 |Fenced |{n}
 
-|Header |{y}
+|Header |{n}
 
 |Literal |{n}
 


### PR DESCRIPTION
In Sections 40.5 (Macros substitutions) and 40.6 (Post Replacements substitutions), change the 2d column values, from check-marks to "X"s, in the "Header" rows in the "Elements subject to [whichever type of] text substitution" tables.

This is related to the repairs discussed in PRs #729 and #730.