### PR TITLE
Update description of "Header" subs-group per #730

### DIFF
--- a/docs/_includes/subs.adoc
+++ b/docs/_includes/subs.adoc
@@ -26,7 +26,7 @@ However, there are a few exceptions.
 The `header` substitution group is applied to metadata lines (author and revision information) in the document header.
 This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 In the header, only special characters and attribute references are replaced.
-In attribute entries, a;sp you can use the <<user-manual#pass-macros,inline pass macro>>.
+In attribute entries, you can also use the <<user-manual#pass-macros,inline pass macro>>.
 
 Fenced, literal, listing, and source blocks are processed with the `verbatim` substitution group.
 Only special characters are replaced in these blocks.

--- a/docs/_includes/subs.adoc
+++ b/docs/_includes/subs.adoc
@@ -23,8 +23,10 @@ include::subs-group-table.adoc[]
 By default, the `normal` substitution group is applied to most block and inline elements.
 However, there are a few exceptions.
 
-The `header` substitution group is applied to the header of your document.
+The `header` substitution group is applied to metadata lines (author and revision information) in the document header.
+This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 In the header, only special characters and attribute references are replaced.
+In attribute entries, a;sp you can use the <<user-manual#pass-macros,inline pass macro>>.
 
 Fenced, literal, listing, and source blocks are processed with the `verbatim` substitution group.
 Only special characters are replaced in these blocks.


### PR DESCRIPTION
One paragraph in Sec. 40 describes the "Header" substitution group. PR #730 has now made important clarifications about that substitution group, in Sec. 13.4.1. This PR applies a minimal update to the description of it in Sec. 40, using some of the new language of Sec. 13.4.1. 

The sentence I've added here about inline pass macros should especially be scrutinized (it might need massaging ;)