### PR TITLE
Explain how pass-macro "preprocesses" attr values

### DIFF
--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -95,10 +95,16 @@ The header substitution group is applied to metadata lines (author and revision 
 This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 
 If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
-In order for the inline macro to be processed, it must completely enclose the attribute value.
-It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
+Basically, it works on the attribute's value like a sort of preprocessor. 
 
-The inline pass macro accepts a list of substitutions in the `target` slot.
+It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
+The inline macro accepts a list of substitutions in the `target` slot.
+In order for the inline pass macro to be processed, it must completely enclose the attribute value.
+
+An attribute value is checked first for an inline pass macro around it. 
+If the macro is absent, the value is processed with the header substitution group.
+
+If the macro is present, it will control what substitutions are used. 
 In the next example, we'll apply the <<user-manual#quotes,quotes substitution>> to an attribute entry's value.
 
 ----

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -95,12 +95,12 @@ The header substitution group is applied to metadata lines (author and revision 
 This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 
 If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
+It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
+
+The inline macro accepts a list of substitutions in the `target` slot.
 In order for the inline pass macro to be processed, it must completely enclose the attribute value.
 
 Basically, it works on the attribute's value like a sort of preprocessor.
-It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
-The inline macro accepts a list of substitutions in the `target` slot.
-
 An attribute value is checked first for an inline pass macro around it.
 If the macro is absent, the value is processed with the header substitution group.
 

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -97,8 +97,8 @@ This group is also applied to the values of attribute entries, regardless of whe
 If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
 It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
 
-The inline macro accepts a list of substitutions in the `target` slot.
-In order for the inline pass macro to be processed, it must completely enclose the attribute value.
+The inline pass macro accepts a list of substitutions in the `target` slot.
+In order for the inline macro to be processed, it must completely enclose the attribute value.
 
 Basically, it works on the attribute's value like a sort of preprocessor.
 An attribute value is checked first for an inline pass macro around it.

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -97,14 +97,14 @@ This group is also applied to the values of attribute entries, regardless of whe
 If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
 Basically, it works on the attribute's value like a sort of preprocessor.
 
-It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
-The inline macro accepts a list of substitutions in the `target` slot.
 In order for the inline pass macro to be processed, it must completely enclose the attribute value.
+The inline macro accepts a list of substitutions in the `target` slot.
+It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
 
 An attribute value is checked first for an inline pass macro around it.
 If the macro is absent, the value is processed with the header substitution group.
 
-If the macro is present, it will determine the substitutions used.
+If the macro is present, it will determine instead the substitutions used.
 In the next example, we'll apply the <<user-manual#quotes,quotes substitution>> to an attribute entry's value.
 
 ----

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -104,7 +104,7 @@ In order for the inline pass macro to be processed, it must completely enclose t
 An attribute value is checked first for an inline pass macro around it.
 If the macro is absent, the value is processed with the header substitution group.
 
-If the macro is present, it will determine the substitutions used. 
+If the macro is present, it will determine the substitutions used.
 In the next example, we'll apply the <<user-manual#quotes,quotes substitution>> to an attribute entry's value.
 
 ----

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -94,12 +94,10 @@ The header substitution group replaces <<user-manual#special-characters,special 
 The header substitution group is applied to metadata lines (author and revision information) in the document header.
 This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 
-If you require different substitutions to be applied to an attribute's value, there are two approaches from which to choose.
-One uses the <<user-manual#pass-macros,inline pass macro>>, to apply alternate substitutions to the enclosed text at the time the attribute is defined.
-
+If you require different substitutions to be applied to an attribute entry's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
 The inline pass macro accepts a list of substitutions in the `target` slot.
-In order for the inline macro to work here, it must completely enclose the attribute value.
 
+In order for the inline macro to work here, it must completely enclose the attribute value.
 Basically, it works on that value like a sort of preprocessor:
 Each attribute value is checked first for an inline pass macro around it.
 If the macro is absent, the value is processed with the header substitution group.

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -94,14 +94,14 @@ The header substitution group replaces <<user-manual#special-characters,special 
 The header substitution group is applied to metadata lines (author and revision information) in the document header.
 This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 
-If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
-It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
+If you require different substitutions to be applied to an attribute's value, there are two approaches from which to choose.
+One uses the <<user-manual#pass-macros,inline pass macro>>, to apply alternate substitutions to the enclosed text at the time the attribute is defined.
 
 The inline pass macro accepts a list of substitutions in the `target` slot.
-In order for the inline macro to be processed, it must completely enclose the attribute value.
+In order for the inline macro to work here, it must completely enclose the attribute value.
 
-Basically, it works on the attribute's value like a sort of preprocessor.
-An attribute value is checked first for an inline pass macro around it.
+Basically, it works on that value like a sort of preprocessor:
+Each attribute value is checked first for an inline pass macro around it.
 If the macro is absent, the value is processed with the header substitution group.
 
 If the macro is present, its list of substitutions will determine instead the substitutions (if any) used on the value.

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -95,13 +95,13 @@ The header substitution group is applied to metadata lines (author and revision 
 This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 
 If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
-Basically, it works on the attribute's value like a sort of preprocessor. 
+Basically, it works on the attribute's value like a sort of preprocessor.
 
 It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
 The inline macro accepts a list of substitutions in the `target` slot.
 In order for the inline pass macro to be processed, it must completely enclose the attribute value.
 
-An attribute value is checked first for an inline pass macro around it. 
+An attribute value is checked first for an inline pass macro around it.
 If the macro is absent, the value is processed with the header substitution group.
 
 If the macro is present, it will determine the substitutions used. 

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -104,7 +104,7 @@ In order for the inline pass macro to be processed, it must completely enclose t
 An attribute value is checked first for an inline pass macro around it. 
 If the macro is absent, the value is processed with the header substitution group.
 
-If the macro is present, it will control what substitutions are used. 
+If the macro is present, it will determine the substitutions used. 
 In the next example, we'll apply the <<user-manual#quotes,quotes substitution>> to an attribute entry's value.
 
 ----

--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -95,16 +95,16 @@ The header substitution group is applied to metadata lines (author and revision 
 This group is also applied to the values of attribute entries, regardless of whether those entries are defined in the header or elsewhere in the document.
 
 If you require different substitutions to be applied to an attribute's value, you can use the <<user-manual#pass-macros,inline pass macro>>.
-Basically, it works on the attribute's value like a sort of preprocessor.
-
 In order for the inline pass macro to be processed, it must completely enclose the attribute value.
-The inline macro accepts a list of substitutions in the `target` slot.
+
+Basically, it works on the attribute's value like a sort of preprocessor.
 It's used to apply alternate substitutions to the enclosed text at the time the attribute is defined.
+The inline macro accepts a list of substitutions in the `target` slot.
 
 An attribute value is checked first for an inline pass macro around it.
 If the macro is absent, the value is processed with the header substitution group.
 
-If the macro is present, it will determine instead the substitutions used.
+If the macro is present, its list of substitutions will determine instead the substitutions (if any) used on the value.
 In the next example, we'll apply the <<user-manual#quotes,quotes substitution>> to an attribute entry's value.
 
 ----


### PR DESCRIPTION
With the aid of Dan's explanation at PR #731, I took a wild stab at broadening Sec. 13.4.1's explanation of how the inline pass macro affects the substitutions happening to an attribute-entry value. 
Emendations (or rejections) expected--and more than welcome!