### PR TITLE
Add another case requiring unconstrained quotes

### DIFF
--- a/docs/_includes/formatting-marks.adoc
+++ b/docs/_includes/formatting-marks.adoc
@@ -57,7 +57,7 @@ She spells her name with an "`h`", as in Sara**h**.
 Consider the following questions:
 
 * Is there a letter, number, underscore directly outside the formatting marks (on either side)?
-* Is there a colon or semi-colon directly before the starting formatting mark?
+* Is there a colon, a semi-colon, or a closing curly bracket directly before the starting formatting mark?
 * Is there a space directly inside of the formatting mark?
 
 If you answered "`yes`" to any of these questions, you need to switch to unconstrained (double formatting) quotes.

--- a/docs/_includes/formatting-marks.adoc
+++ b/docs/_includes/formatting-marks.adoc
@@ -57,7 +57,7 @@ She spells her name with an "`h`", as in Sara**h**.
 Consider the following questions:
 
 * Is there a letter, number, underscore directly outside the formatting marks (on either side)?
-* Is there a colon, a semi-colon, or a closing curly bracket directly before the starting formatting mark?
+* Is there a colon, semi-colon, or closing curly bracket directly before the starting formatting mark?
 * Is there a space directly inside of the formatting mark?
 
 If you answered "`yes`" to any of these questions, you need to switch to unconstrained (double formatting) quotes.


### PR DESCRIPTION
Where the User Manual gives us the conditions under which we need to use unconstrained (rather than constrained)  quotes (Sec. 12.3), it lists a couple of marks which, only when they appear directly before the opening quote, require it:

- Is there a colon or semi-colon directly before the starting formatting mark?

But in my experimentation, it seems that a closing curly bracket causes the same necessity. 

This is the case, for example, when you have an attribute reference immediately before the starting formatting mark and you are using quote-substitution before attribute-ref-substitution--as in the normal substitution ordering.

Am I by any chance right about this?? :D