### PR TITLE
Added plus-based monospace example

### DIFF
--- a/docs/_includes/ex-text.adoc
+++ b/docs/_includes/ex-text.adoc
@@ -89,7 +89,7 @@ _italic phrase_ & __char__acter__s__
 ``++char{plus}++``acter``++s++``
 
 (compat-mode only, deprecated) +monospace phrase {plus} link:.[this page]+ &
-++char{plus}++act{dash}er++s++ 
+++char{plus}++act{dash}er++s++
 
 `*monospace bold phrase*` & ``**char**``acter``**s**``
 

--- a/docs/_includes/ex-text.adoc
+++ b/docs/_includes/ex-text.adoc
@@ -146,7 +146,8 @@ The vial's label read: E=mc^2^; `the scent of science`; `_smell like a genius_`.
 // end::mono[]
 
 // tag::b-mono-code[]
-Reference code like `types` or `methods` inline.
+Reference a `Class` or an `instance{plus}member` inline.
+Also reference ``Class``es or ``instance{plus}member``s.
 // end::b-mono-code[]
 
 // tag::highlight[]

--- a/docs/_includes/ex-text.adoc
+++ b/docs/_includes/ex-text.adoc
@@ -85,8 +85,8 @@ _italic phrase_ & __char__acter__s__
 `monospace phrase {plus} link:.[this page]` &
 ``char{plus}``acter``s``
 
-+monospace phrase {plus} link:.[this page]+ &
-++char{plus}++acter++s++ (plus)
+(compat-mode only, deprecated) +monospace phrase {plus} link:.[this page]+ &
+++char{plus}++act{dash}er++s++ 
 
 `*monospace bold phrase*` & ``**char**``acter``**s**``
 

--- a/docs/_includes/ex-text.adoc
+++ b/docs/_includes/ex-text.adoc
@@ -82,7 +82,11 @@ _italic phrase_ & __char__acter__s__
 
 *_bold italic phrase_* & **__char__**acter**__s__**
 
-`monospace phrase` & ``char``acter``s``
+`monospace phrase {plus} link:.[this page]` &
+``char{plus}``acter``s``
+
++monospace phrase {plus} link:.[this page]+ &
+++char{plus}++acter++s++ (plus)
 
 `*monospace bold phrase*` & ``**char**``acter``**s**``
 

--- a/docs/_includes/ex-text.adoc
+++ b/docs/_includes/ex-text.adoc
@@ -85,6 +85,9 @@ _italic phrase_ & __char__acter__s__
 `monospace phrase {plus} link:.[this page]` &
 ``char{plus}``acter``s``
 
+`+passthrough monospace phrase {plus} link:.[this page]+` &
+``++char{plus}++``acter``++s++``
+
 (compat-mode only, deprecated) +monospace phrase {plus} link:.[this page]+ &
 ++char{plus}++act{dash}er++s++ 
 


### PR DESCRIPTION
Asciidoc user guide (http://asciidoc.org/userguide.html#_text_formatting ) shows monospace formatting can be specified using backtick or plus.