### PR TITLE
Emend :stylesdir: to navigate via parent directory

### DIFF
--- a/docs/_includes/apply-theme.adoc
+++ b/docs/_includes/apply-theme.adoc
@@ -85,7 +85,7 @@ For `a.adoc` and `b.adoc`, set `stylesdir` to:
 For `c.adoc`, set `stylesdir` to:
 
 ----
-:stylesdir: ./mystylesheets
+:stylesdir: ../mystylesheets
 ----
 
 If you're serving your documents from a webserver, you can solve this problem by providing an absolute path to the stylesheet.


### PR DESCRIPTION
Correct me if I'm wrong, but in this final Sec.-76 code-example, the first directory-move must be to the directory (/mydocuments) which is the parent of the directory (/mynesteddocuments) that contains the current file (c.adoc), since said parent is the directory that contains the directory you're trying to reference (/mystylesheets). So, the single-dot should be a double-dot, in the filepath.