### PR TITLE
Add note for unsupported automatic section title resolution

### DIFF
--- a/docs/asciidoc-syntax-quick-reference.adoc
+++ b/docs/asciidoc-syntax-quick-reference.adoc
@@ -549,6 +549,8 @@ include::{includedir}/ex-xref.adoc[tag=b-base]
 include::{includedir}/ex-xref.adoc[tag=b-inter]
 ----
 
+NOTE: Asciidoctor cannot (yet) automatically resolve the section title from the separate document.
+
 == Images
 
 Images are resolved relative to the value of the {uri-imagesdir}[imagesdir] document attribute, which is empty by default.


### PR DESCRIPTION
It feels natural to users that section titles for inter-doc references
should be resolved automatically as it also happens for internal cross
references.

This limitation is clearly documented in the User Manual but I believe a
small note is warranted also in the quick reference so people who are
looking at the reference and still try to make this work.

Relates to: asciidoctor/asciidoctor#2500