### PR TITLE
Fix misspelling in xrefstyle section

### DIFF
--- a/docs/_includes/xrefstyle.adoc
+++ b/docs/_includes/xrefstyle.adoc
@@ -62,7 +62,7 @@ Installation
 ====
 
 The *full* and *short* styles only apply for references that have a caption.
-Specifically, the cooresponding `*-caption` attribute must be set for the target's block type (e.g., `listing-caption` for listing blocks, `example-caption` for example blocks, `table-caption` for tables, etc).
+Specifically, the corresponding `*-caption` attribute must be set for the target's block type (e.g., `listing-caption` for listing blocks, `example-caption` for example blocks, `table-caption` for tables, etc).
 Otherwise, the *basic* style is used.
 
 You can use document attributes to customize the signifier that is placed in front of the reference's number.


### PR DESCRIPTION
This fixes a spelling in the section about `xrefstyle`.