### PR TITLE
Fix LICENSE link

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -24,7 +24,7 @@ Discover Asciidoctor and how it can help you.
 
 * link:/#authors[Who created Asciidoctor?]
 
-* link:http://github.com/asciidoctor/asciidoctor/blob/master/LICENSE.adoc[What is the Asciidoctor license?]
+* link:http://github.com/asciidoctor/asciidoctor/blob/master/LICENSE[What is the Asciidoctor license?]
 
 * link:user-manual/#compared-to-markdown[How do AsciiDoc and Markdown differ?]
 


### PR DESCRIPTION
The link is 404 in the live site