### PR TITLE
Fix typo

### DIFF
--- a/docs/_includes/conditional-preprocessor-directives.adoc
+++ b/docs/_includes/conditional-preprocessor-directives.adoc
@@ -113,7 +113,7 @@ The `ifndef` directive negates the results of the expression.
 WARNING: Starting in Asciidoctor 1.5.6, the operator logic in the `ifndef` directive changed to align with the behavior of AsciiDoc Python.
 Specifically, when attributes are separated by commas, content is only included if none of the attributes are defined.
 When attributes are separated by pluses, content is included if at least one of the attributes is undefined.
-See https://github.com/asciidoctor/asciidoctor/issues/1983[issue #1983] to find the discussion about this behavior and the rational for the change.
+See https://github.com/asciidoctor/asciidoctor/issues/1983[issue #1983] to find the discussion about this behavior and the rationale for the change.
 
 === ifeval directive
 


### PR DESCRIPTION
Fix typo ("rational" to "rationale")