### PR TITLE
Add replacements subs for attributes tables

### DIFF
--- a/docs/_includes/attrs-charref.adoc
+++ b/docs/_includes/attrs-charref.adoc
@@ -4,7 +4,7 @@
 [#charref-attributes-table]
 // tag::table[]
 .Predefined attributes for character replacements ^[1][2][3]^
-[width="75%", cols="^4l,^3l,^3",subs="replacements"]
+[width="75%", cols="^4l,^3l,^3",subs="normal"]
 |===
 |Attribute name |Replacement text |Appearance
 

--- a/docs/_includes/attrs-charref.adoc
+++ b/docs/_includes/attrs-charref.adoc
@@ -4,7 +4,7 @@
 [#charref-attributes-table]
 // tag::table[]
 .Predefined attributes for character replacements ^[1][2][3]^
-[width="75%", cols="^4l,^3l,^3"]
+[width="75%", cols="^4l,^3l,^3",subs="replacements"]
 |===
 |Attribute name |Replacement text |Appearance
 


### PR DESCRIPTION
This way, `wj^[5]^` can be displayed as a footnote link.
At the moment, it is displayed as plain `wj^[5]^`.