### PR TITLE
Fix allowed value for :copycss:

### DIFF
--- a/docs/_includes/attrs-builtin.adoc
+++ b/docs/_includes/attrs-builtin.adoc
@@ -878,7 +878,7 @@ _Introduced in 1.5.6._
 |copycss
 |If set, copy the CSS files to the output.
 |_empty_ (File is copied if `linkcss` is set).
-|_empty_
+|Location of the stylesheet
 |{y}
 |<<applying-a-theme>>
 

--- a/docs/_includes/attrs-builtin.adoc
+++ b/docs/_includes/attrs-builtin.adoc
@@ -878,7 +878,7 @@ _Introduced in 1.5.6._
 |copycss
 |If set, copy the CSS files to the output.
 |_empty_ (File is copied if `linkcss` is set).
-|Location of the stylesheet
+|Empty or the location of the custom stylesheet (if used)
 |{y}
 |<<applying-a-theme>>
 


### PR DESCRIPTION
The **Allowed values** field for the `copycss` attribute erroneously says *empty*. Instead, it should say that the value needs to specify the location of the stylesheet (provided we don't want the `stylesheet` attribute to resolve relative to the base directory. This PR fixes that.

See also https://github.com/asciidoctor/asciidoctor/issues/300#issuecomment-26478893.