### PR TITLE
configure settings for Netlify deploy preview

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -124,9 +124,11 @@ end
 namespace :deploy do
 desc 'Generate site from Netlify'
 task :netlify do
+  profile = ENV['CONTEXT'] || 'production'
   reject_trailing_whitespace
   # TODO set_pub_dates 'master'
-  run_awestruct '-P production -g --force -q', :spawn => false
+  url_opt = %( -u #{ENV['DEPLOY_PRIME_URL']}) unless profile == 'production'
+  run_awestruct %(-P #{profile}#{url_opt} -g --force -q), :spawn => false
 end
 
 desc 'Generate site from Travis CI and, if not a pull request, publish site to production (GitHub Pages)'

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -9,7 +9,7 @@ disqus_generate_id: true
 disqus_developer: true
 asciidoctor:
   :safe: :unsafe
-  :base_dir: null
+  :base_dir: ~
   :attributes:
     allow-uri-read: ''
     #cache-uri: ''
@@ -23,7 +23,7 @@ asciidoctor:
     linkattrs: ''
     #source-highlighter: 'highlight.js'
     source-highlighter: 'coderay'
-    prewrap: null
+    prewrap: ~
 haml:
   :ugly: true
 slim|html:
@@ -31,10 +31,10 @@ slim|html:
 # NOTE if no profile is specified, the first with a deploy config is selected
 profiles:
   development:
-    deploy: null
+    deploy: ~
     #show_drafts: false
-  staging:
-    deploy: null
+  deploy-preview:
+    deploy: ~
   production:
     base_url: https://asciidoctor.org
     disqus_developer: false
@@ -48,6 +48,7 @@ profiles:
     #compass_output_style: compressed
     # TODO enable minify once we verify it's working as expected
     #minify: true
-    deploy:
-      host: github_pages
-      branch: gh-pages
+    deploy: ~
+    #deploy:
+    #  host: github_pages
+    #  branch: gh-pages

--- a/_ext/awestruct_ext.rb
+++ b/_ext/awestruct_ext.rb
@@ -60,7 +60,7 @@ Asciidoctor::Extensions.register do
       account_id = doc.attr 'site-google_analytics_account'
       output
         .sub('</title>', %(</title>
-<script>!function(l,p){if(l.protocol!==p&&l.host=="asciidoctor.org")l.protocol=p}(location,"https:")</script>))
+<script>!function(l,p){if(l.protocol!==p){l.protocol=p}else if(l.host=="asciidoctor.netlify.com"){l.host="asciidoctor.org"}}(location,"https:")</script>))
         .rstrip.chomp('</html>').rstrip.chomp('</body>').chomp
         .concat(%(
 <script>
@@ -69,11 +69,15 @@ Asciidoctor::Extensions.register do
 </body>
 </html>))
     end
-  end unless ::Awestruct::Engine.instance.development?
+  end if ::Awestruct::Engine.instance.production?
 end
 
 module Awestruct
   class Engine
+    def production?
+      site.profile == 'production'
+    end
+
     def development?
       site.profile == 'development'
     end

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -22,7 +22,7 @@ Awestruct::Extensions::Pipeline.new do
   extension Awestruct::Extensions::Indexifier.new
   unless engine.development?
     extension Awestruct::Extensions::Atomizer.new :posts, '/feed.atom', :template => '_layouts/feed.atom.haml'
-    extension Awestruct::Extensions::Disqus.new
+    extension Awestruct::Extensions::Disqus.new if engine.production?
   end
 
   #transformer Awestruct::Extensions::Minify.new([:js])

--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -4,8 +4,8 @@ doctype 5
 head
   meta charset='utf-8'
   meta name='viewport' content='width=device-width, initial-scale=1.0'
-  - if site.base_url == 'https://asciidoctor.org'
-    |<script>!function(l,p){if(l.protocol!==p){l.protocol=p}else if(l.host=="asciidoctor.netlify.com"){l.replace(p+"//asciidoctor.org/"+l.pathname.substr(l.pathname.indexOf("/",1))+l.search+l.hash)}}(location,"https:")</script>
+  - if site.engine.production?
+    |<script>!function(l,p){if(l.protocol!==p){l.protocol=p}else if(l.host=="asciidoctor.netlify.com"){l.host="asciidoctor.org"}}(location,"https:")</script>
   link rel='stylesheet' href='/stylesheets/styles.css'
   script src='/javascripts/vendor/custom.modernizr.js'
   title=((page.title && page.title != site.title ? [page.title, site.title] : [site.title, site.description]) * ' | ').gsub(/<(\/?[^>]+)>/) { $~[1].start_with?('/') ? ')' : '(' }


### PR DESCRIPTION
- set awestruct profile to match Netlify context
- add deploy-preview profile to site config
- set -u flag using value of DEPLOY_PRIME_URL env var if context is not production
- simplify script to redirect from asciidoctor.netlify.com to asciidoctor.org
- add production? helper method to Engine
- disable disqus unless profile is production