### PR TITLE
Update reference to http to be https

### DIFF
--- a/docs/_includes/url.adoc
+++ b/docs/_includes/url.adoc
@@ -48,7 +48,7 @@ When the hide-uri-scheme attribute is set, the above URL will render as follows:
 <a href="https://asciidoctor.org">asciidoctor.org</a>
 ----
 
-Note the absence of _http_ inside the `<a>` element.
+Note the absence of _https_ inside the `<a>` element.
 
 To attach a URL to text, enclose the text in square brackets at the end of the URL.
 


### PR DESCRIPTION
When describing the hide-uri-scheme attribute the documentation uses an https url, but then says note the absence of http in the url. Given it is https I expect this was an oversight.

I'm sorry if there are contribution guidelines I'm supposed to follow I couldn't find any.