### PR TITLE
Emend demo code for registering treeprocessor

### DIFF
--- a/docs/_includes/exten-tree.adoc
+++ b/docs/_includes/exten-tree.adoc
@@ -61,7 +61,7 @@ end
 .Usage
 
 ```ruby
-Asciidoctor::Extensions.register do |document|
+Asciidoctor::Extensions.register do
   treeprocessor ShellSessionTreeProcessor
 end
 


### PR DESCRIPTION
I don't think having a |document| parameter is correct here, for the code-block passed to Asciidoctor::Extensions.register ...?? (It didn't work when I tried it, anyway--but I'm not sure why! :)