### PR TITLE
remind 'em that doctype=book implies chap.=level 1

### DIFF
--- a/docs/_includes/sections.adoc
+++ b/docs/_includes/sections.adoc
@@ -224,5 +224,7 @@ include::ex-section.adoc[tag=sectnuml]
 ----
 <1> When the `sectnumlevels` attribute is assigned a value of `2`, section titles with levels 3 through 5 are not numbered (i.e., not prefixed with a number).
 
+When your `doctype` is `book`, remember that your "`section levels`" counts the chapter as one level; thus, `:secnumlevels: 4` means a chapter number and then 3 section levels are allowed.
+
 Assigning `sectnumlevels` a value of `0` is effectively the same as disabling section numbering (i.e., `sectnums!`).
 // end::number[]


### PR DESCRIPTION
Probably there's a better wording; someone please supply it.