### PR TITLE
transpose sections 72 and 73

### DIFF
--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -1194,16 +1194,6 @@ The Asciidoctor project includes alternative stylesheet themes from <<stylesheet
 You can also create your own <<custom-themes,themes>> and <<custom-backends,backends>>.
 --
 
-== Custom Themes
-
-=== Creating a Theme
-
-include::{includedir}/create-theme.adoc[]
-
-=== Applying a Theme
-
-include::{includedir}/apply-theme.adoc[]
-
 == Stylesheet Factory
 
 include::{includedir}/factory-intro.adoc[]
@@ -1231,6 +1221,16 @@ include::{includedir}/factory-gen.adoc[]
 === External Preview
 
 include::{includedir}/factory-preview.adoc[]
+
+== Custom Themes
+
+=== Creating a Theme
+
+include::{includedir}/create-theme.adoc[]
+
+=== Applying a Theme
+
+include::{includedir}/apply-theme.adoc[]
 
 == Slide Decks
 

--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -1194,6 +1194,10 @@ The Asciidoctor project includes alternative stylesheet themes from <<stylesheet
 You can also create your own <<custom-themes,themes>> and <<custom-backends,backends>>.
 --
 
+== Applying a Theme
+
+include::{includedir}/apply-theme.adoc[]
+
 == Stylesheet Factory
 
 include::{includedir}/factory-intro.adoc[]
@@ -1210,6 +1214,10 @@ include::{includedir}/factory-setup.adoc[tag=gem]
 
 include::{includedir}/factory-setup.adoc[tag=build]
 
+=== Creating a Theme
+
+include::{includedir}/create-theme.adoc[]
+
 === Applying a Stylesheet
 
 include::{includedir}/factory-apply.adoc[]
@@ -1221,16 +1229,6 @@ include::{includedir}/factory-gen.adoc[]
 === External Preview
 
 include::{includedir}/factory-preview.adoc[]
-
-== Custom Themes
-
-=== Creating a Theme
-
-include::{includedir}/create-theme.adoc[]
-
-=== Applying a Theme
-
-include::{includedir}/apply-theme.adoc[]
 
 == Slide Decks
 


### PR DESCRIPTION
Put the material in the (logical) order it appeared in the README.adoc in the Stylesheet Factory GitHub page (https://github.com/asciidoctor/asciidoctor-stylesheet-factory). After all, you can't know even what folders the current section 72 is talking about, till you've started Sec. 73. It wasn't until I read the GitHub page that I could see that the User Manual had somehow gotten these sections out of the didactically logical order that appears on GitHub. There might be a few tweaks that could help, in addition to this transposition of the sections; but just the transposition, with nothing else done, would make the material vastly more intelligible--IMHO.