### PR TITLE
Fix attribute reference in preface note

### DIFF
--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -118,7 +118,7 @@ Sarah White <https://github.com/graphitefriction[@graphitefriction]>; Dan Allen 
 [NOTE]
 ====
 If you find errors or omissions in this document, please don't hesitate to {uri-ad-org-issues}[submit an issue or open a pull request] with a fix.
-We also encourage you to ask questions and discuss any aspects of the project on the {uri-mailinglist}[mailing list] or in the {uri-irc}[chat room].
+We also encourage you to ask questions and discuss any aspects of the project on the {uri-mailinglist}[mailing list] or in the {uri-chat}[chat room].
 New contributors are always welcome!
 ====
 


### PR DESCRIPTION
When the IRC link was changed to Gitter, the `uri-irc` reference was left in the note, resulting in the markup rendering verbatim.