### PR TITLE
fix typo in docs/_includes/ex-dlist.adoc

### DIFF
--- a/docs/_includes/ex-dlist.adoc
+++ b/docs/_includes/ex-dlist.adoc
@@ -43,7 +43,7 @@ second term:: definition of second term
 // tag::b-base-multi[]
 first term::
 definition of first term
-section term::
+second term::
 definition of second term
 // end::b-base-multi[]
 


### PR DESCRIPTION
A `second term` has been mistakenly spelled `section term`.

(Else the french translation on which I'm working on is 50% complete, regarding the asciidoc-syntax-quick-reference… it's a slow work, but I'm not alone to work on)