### PR TITLE
Another typo (attrs_charref)

### DIFF
--- a/docs/_includes/attrs-charref.adoc
+++ b/docs/_includes/attrs-charref.adoc
@@ -140,5 +140,5 @@ Instead, use numeric character references (e.g., \&#8364;).
 
 ^[4]^ The Zero Width Space (ZWSP) is a code point in Unicode that shows where a long word can be split if necessary.
 
-^[5]^ The word joiner (WJ) is a code point in Unicode prevents a line break at its position.
+^[5]^ The word joiner (WJ) is a code point in Unicode that prevents a line break at its position.
 // end::table[]


### PR DESCRIPTION
Else… I'm proofreading our complete french translation for the asciidoc-syntax-quick-reference.fr.adoc.