### PR TITLE
Fix trivial syntax error in User Manual

### DIFF
--- a/docs/_includes/html-styles.adoc
+++ b/docs/_includes/html-styles.adoc
@@ -27,7 +27,7 @@ You can also set linkcss with the CLI.
 
  $ asciidoctor -a linkcss mysample.adoc
 
-Now, when you view the directory, you should see the file [.path]_asciidoctor.css_ in addition to[.path]_mysample.adoc_ and [.path]_mysample.html_.
+Now, when you view the directory, you should see the file [.path]_asciidoctor.css_ in addition to [.path]_mysample.adoc_ and [.path]_mysample.html_.
 The linkcss attribute automatically copies asciidoctor.css to the output directory.
 Additionally, you can inspect [.path]_mysample.html_ in your browser and see `<link rel="stylesheet" href="./asciidoctor.css">` inside the `<head>` tags.
 


### PR DESCRIPTION
Add missing space in User Manual `html-styles.adoc`, which prevents
correct page generation at
<http://asciidoctor.org/docs/user-manual/#styling-the-html-with-css>.