### PR TITLE
Add htmlbook and link the asciidoctor-backends repo to template examples

### DIFF
--- a/docs/_includes/templates-api.adoc
+++ b/docs/_includes/templates-api.adoc
@@ -22,4 +22,4 @@ To use Haml as the template engine, you'd name the templates `document.html.haml
 Templates for block elements, like a paragraph or sidebar, are named after the block they handle.
 For instance, to override the default paragraph template with an ERB template, put a file named `paragraph.html.erb` in the template directory you pass to the `Document` constructor using the `:template_dir` option.
 
-For more usage examples, see the (massive) {tests}[test suite].
+For more usage examples, see the {backend-git}[asciidoctor-backends], the O'Reilly {uri-asciidoctor-htmlbook}[htmlbook] project and the (massive) {tests}[test suite].

--- a/docs/user-manual.adoc
+++ b/docs/user-manual.adoc
@@ -114,6 +114,7 @@ Sarah White <https://github.com/graphitefriction[@graphitefriction]>; Dan Allen 
 :uri-asciidoctor-pdf: https://github.com/asciidoctor/asciidoctor-pdf
 :uri-asciidoctor-pdf-readme: https://github.com/asciidoctor/asciidoctor-pdf/blob/master/README.adoc
 :uri-asciidoctor-pdf-theming-guide: http://gist.asciidoctor.org/?github-asciidoctor%2Fasciidoctor-pdf%2F%2Fdocs%2Ftheming-guide.adoc
+:uri-asciidoctor-htmlbook: https://github.com/oreillymedia/asciidoctor-htmlbook
 
 [NOTE]
 ====


### PR DESCRIPTION
These examples would have helped me a few weeks ago, I thought we should add them to the docs.
The test suite has almost no examples but asciidoctor-backends is like gold for someone wanting to use templates.