### PR TITLE
Add 'Attribute List' to the list of block elements

### DIFF
--- a/docs/_includes/element.adoc
+++ b/docs/_includes/element.adoc
@@ -29,6 +29,7 @@ A document can include the following block elements:
 * Block Title
 * Block Macro
 * Block
+* Attribute List
 * Paragraph
 * Delimited Block
 * Table


### PR DESCRIPTION
Attribute List is, I suspect, an item that should be in our User Manual's list of block elements. It is mentioned in the AsciiDoc User Guide's [discussion of such](http://asciidoc.org/asciidoc.css-embedded.html#_block_elements), and its importance as a block element seems underscored by the (ongoing) discussion at #745.