### PR TITLE
Strengthen to +++ the + around mention of pass:[]

### DIFF
--- a/docs/_includes/attr-doc.adoc
+++ b/docs/_includes/attr-doc.adoc
@@ -177,7 +177,7 @@ To learn about how these substitutions work, refer to the <<user-manual#subs,Sub
 
 ==== Altering attribute entry substitutions
 
-If you want the value of an attribute entry to be used *as is*, or you want to alter the substitutions that are applied, you can enclose the value in the <<user-manual#pass-macros,inline pass macro>> (i.e., `+pass:[]+`).
+If you want the value of an attribute entry to be used *as is*, or you want to alter the substitutions that are applied, you can enclose the value in the <<user-manual#pass-macros,inline pass macro>> (i.e., `+++pass:[]+++`).
 The inline pass macro accepts a list of zero or more substitutions in the target slot, which can be used to control which substitutions are applied to the value.
 
 In order for the inline macro to work in this context, it must completely surround the attribute value.


### PR DESCRIPTION
In Sec. 10.4.3 of the User Manual, end of first sentence, someone attempted an inline mention of `pass:[]` by embedding it in a single-plus passthru macro: `+pass:[]+`. But for whatever reason, single-plus doesn't suffice with this content: it produces only an empty `<code></code>` element in the output.

Using the triple-plus passthru does work, however: `+++pass:[]+++`.