### PR TITLE
Update ex-rev.adoc

### DIFF
--- a/docs/_includes/ex-rev.adoc
+++ b/docs/_includes/ex-rev.adoc
@@ -34,7 +34,7 @@ My document provides...
 // tag::attr[]
 = The Dangerous and Thrilling Documentation Chronicles
 Kismet Chameleon <kismet@asciidoctor.org>
-:revnumber: 1.0 // <1>
+:revnumber: V1.0 // <1>
 :revdate: 10-02-2013
 :revremark: The first incarnation of {doctitle} // <2>
 :version-label!: // <3>


### PR DESCRIPTION
Add V in `revnumber` to make it consistent with: (asciidoctor.org/docs/_includes/revision.adoc)

- `In the converted document, notice that the V preceding the revnumber is capitalized in the byline but not when the attribute is referenced in the body of the document.`
- `When explicitly set, any characters preceding the version number are not dropped.`