### PR TITLE
Add missing metadata name `citetitle`

### DIFF
--- a/docs/_includes/block.adoc
+++ b/docs/_includes/block.adoc
@@ -29,6 +29,7 @@ In addition to a title, a block can be assigned additional metadata including:
 * Id (i.e., anchor)
 * Block name (first positional attribute)
 * Block attributes
+* Cite title
 
 Here's an example of a quote block with metadata:
 


### PR DESCRIPTION
Add the missing metadata name `citetitle` to the listing before the example.