### PR TITLE
Update website ref: Asciidoctor-reveal.js 2.0.0 is released

### DIFF
--- a/docs/asciidoctor-revealjs.adoc
+++ b/docs/asciidoctor-revealjs.adoc
@@ -1,13 +1,11 @@
 // NOTE include file is not resolved when reading the header only, hence the extra attributes
 :doctitle: Asciidoctor Reveal.js
-:revnumber: 1.1.3
+:revnumber: 2.0.0
 :gitref: v{revnumber}
 :keywords: Asciidoctor Reveal.js, AsciiDoc, Asciidoctor, reveal.js, slides
 :page-keywords: {keywords}
 :page-layout: docs
-include::https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor-reveal.js/README.adoc[]
-// FIXME switch to concrete ref when 1.1.4 is released
-//include::https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor-reveal.js@{gitref}/README.adoc[]
+include::https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor-reveal.js@{gitref}/README.adoc[]
 
 == Stay Connected
 


### PR DESCRIPTION
Took the liberty to handle the FIXME. The link works so it looks ok.