### PR TITLE
fix(lists): remove leading space from list examples in user manual

### DIFF
--- a/docs/_includes/ex-o-list.adoc
+++ b/docs/_includes/ex-o-list.adoc
@@ -20,9 +20,9 @@ Included in:
 
 // tag::base-start[]
 [start=4]
- . Step four
- . Step five
- . Step six
+. Step four
+. Step five
+. Step six
 // end::base-start[]
 
 // tag::base-num[]

--- a/docs/asciidoc-vs-markdown.adoc
+++ b/docs/asciidoc-vs-markdown.adoc
@@ -319,8 +319,8 @@ a|
 ----
 * apples
 * oranges
- ** temple
- ** navel
+** temple
+** navel
 * bananas
 ----
 |Ordered list


### PR DESCRIPTION
* https://asciidoctor-docs.netlify.com/asciidoctor/1.5/project/asciidoc-vs-markdown/
  - First noticed here
  - Submitted PR: https://github.com/asciidoctor/asciidoctor/pull/3125

---

Essentially, keep the examples consistent with the rest of the examples in the user manual.