### PR TITLE
Fix Prettify Link

### DIFF
--- a/docs/_includes/src.adoc
+++ b/docs/_includes/src.adoc
@@ -53,7 +53,7 @@ The following table lists the recognized values for the `source-highlighter` att
 |highlightjs
 |Asciidoctor, AsciidoctorJ, Asciidoctor.js
 
-|https://code.google.com/p/google-code-prettify[prettify]
+|https://github.com/google/code-prettify[prettify]
 |prettify
 |Asciidoctor, AsciidoctorJ, Asciidoctor.js
 


### PR DESCRIPTION


# Fix Prettify Syntax Highlighter Link

The link to prettify highlight in _[§46.2. Available Source Highlighters]_ is obsolete, prettify has now officially moved to GitHub.

Old link:

- https://code.google.com/archive/p/google-code-prettify/

New link:

- https://github.com/google/code-prettify


[§46.2. Available Source Highlighters]: https://asciidoctor.org/docs/user-manual/#available-source-highlighters

<!-- EOF -->
