### PR TITLE
make markdown URI reference example more idiomatic

### DIFF
--- a/docs/asciidoc-vs-markdown.adoc
+++ b/docs/asciidoc-vs-markdown.adoc
@@ -436,9 +436,9 @@ a|
 a|
 [source,markdown]
 ----
-[home]: https://example.org "Home"
-
 Go [home].
+
+[home]: https://example.org "Home"
 ----
 a|
 [source,asciidoc]


### PR DESCRIPTION
In markdown, URI references are usually put **after** the main content. Let's do this in comparison, to show that in asciidoctor you have to put it before


Am I correct that it's impossible to achieve markdown behavior with asciidoctor? When writing blog posts in markdown, I tend to have a block of links after each paragraph. I wonder what is the suggested approach to this in asciidoctor? Specifying URLs inline is bad, because urls are long and distract from content.

Specifing `:attr: http://long-url` *before* paragraph works, but feels ... backwards? References and footnotes are usually specified after the content.