### PR TITLE
Adds explanation about HTML relative image sizing support

### DIFF
--- a/docs/_includes/image-sizing.adoc
+++ b/docs/_includes/image-sizing.adoc
@@ -91,6 +91,7 @@ DocBook also accepts the `width` attribute if `scaledwidth` is not provided.
 (assumed to be px)
 |Not possible
 |width=50%
+(Subject to browser support)
 |Not possible
 
 |pdf

--- a/docs/_includes/sum-image.adoc
+++ b/docs/_includes/sum-image.adoc
@@ -41,13 +41,13 @@ Included in:
 |User defined size in pixels
 |`image::sunset.jpg[Sunset,300]` +
 (or `width=300`)
-|
+|Limited support for relative value available in HTML (`width=50%`)
 
 |height
 |User defined size in pixels
 |`image::sunset.jpg[Sunset,300,200]` +
 (or `height=200`)
-|
+|Limited support for relative to content value available in HTML (`height=50%`)
 
 |link
 |User defined location of external URI


### PR DESCRIPTION
As mentioned in https://github.com/asciidoctor/asciidoctor.org/issues/866.

This PR attempts to reduce ambiguity in the image sizing summaries.