### PR TITLE
Installing the asciidoctor-firefox-addon.xpi fails

### DIFF
--- a/docs/editing-asciidoc-with-live-preview.adoc
+++ b/docs/editing-asciidoc-with-live-preview.adoc
@@ -38,7 +38,7 @@ If you want the latest and greatest version you can use the direct download link
 
 ==== Firefox
 
-. Download {uri-firefox-addon-dd}[asciidoctor-firefox-addon.xpi]
+. Download {uri-firefox-addon-dd}[asciidoctor-firefox-addon.xpi] or https://addons.mozilla.org/en-US/firefox/addon/asciidoctorjs-live-preview/?src=search
 . Open the file with Firefox to install
 
 ==== Opera


### PR DESCRIPTION
Firefox 67.0 on Linux Mint says the xpi here is corrupt. As a workaround, I am adding the link to the mozilla.org site, the live preview pluging there works fine for me.

You may want to fix this differently, of course.