### PR TITLE
LICENSE file for website content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
+
+This is a human-readable summary of (and not a substitute for) the license: https://creativecommons.org/licenses/by-sa/3.0/legalcode
+
+You are free to:
+Share — copy and redistribute the material in any medium or format
+Adapt — remix, transform, and build upon the material for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+Under the following terms:
+
+Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+Notices:
+
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.


### PR DESCRIPTION
The asciidoctor.org website specifies in its footer that the content on the site is CC BY SA 3.0, and that would seem to be the license that all the files in this repo are under. 

For example, if I am grabbing a template to use as-is or modify for my project, I want to properly attribute that template (presuming I can merge in from a CC license, which I can in my personal case).

It seems that you intend the entirety of this repo to be CC BY SA 3.0.

So I am proposing this LICENSE file to live in the repo with the soruce files to make it clear what the content here is licensed under. This also makes attribution (BY term) easier to follow, because one can link directly to the file in the git repo rather than the rendered HTML page on asciidoctor.org.