### PR TITLE
Align multi-line attribute info

### DIFF
--- a/docs/asciidoc-recommended-practices.adoc
+++ b/docs/asciidoc-recommended-practices.adoc
@@ -282,9 +282,9 @@ The description is included in the header of the document.
 
  :description: This document catalogs a set of recommended practices for writing in AsciiDoc.
 
-You can break any attribute value across several lines by ending the lines in a `+{plus}+` preceded by a space.
+You can break any <<user-manual#splitting-attribute-values-over-multiple-lines,attribute value across several lines>> by ending the lines in a `+{backslash}+` preceded by a space.
 
- :description: This document catalogs a set of recommended practices +
+ :description: This document catalogs a set of recommended practices \
                for composing documents in AsciiDoc.
 
 You can use this text anywhere in the document by referencing it as an attribute.


### PR DESCRIPTION
Aligned recommended-practices for multi-line attribute with reference doc found here: https://asciidoctor.org/docs/user-manual/#splitting-attribute-values-over-multiple-lines

PS: Please double check, if introduced link to user manual is correctly leading to attribute splitting section.