### PR TITLE
google+ no longer active

### DIFF
--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -78,10 +78,6 @@ body.antialiased
               i.fa.fa-fw.fa-twitter
               =<> 'Twitter:'
               a.twitter href='https://twitter.com/asciidoctor' @asciidoctor
-              br
-              i.fa.fa-fw.fa-google-plus-sign
-              =<> 'Google+:'
-              a href='https://plus.google.com/116431294697916948181' rel='publisher' Asciidoctor
 
       .large-6.large-text-right.columns
         p style='margin-bottom: 0'


### PR DESCRIPTION
This change removes the link from the template. 
I was unable to test this locally due to general problems with rake in my installation. 
I hope Netlify will provide a preview.