### PR TITLE
Add missing footnote links in attr-envs.adoc

### DIFF
--- a/docs/_includes/attrs-env.adoc
+++ b/docs/_includes/attrs-env.adoc
@@ -69,7 +69,7 @@ _Introduced in 1.5.6._
 |article
 
 |docyear
-|Year that the document was last modified.^[1,2]^
+|Year that the document was last modified.^[<<note_docdatetime,1>>,<<note_sourcedateepoch,2>>]^
 |2018
 
 |embedded
@@ -97,7 +97,7 @@ _Introduced in 1.5.6._
 |19:31:05 UTC
 
 |localyear
-|Year when the document was converted.^[2]^
+|Year when the document was converted.^[<<note_sourcedateepoch,2>>]^
 |2018
 
 |outdir


### PR DESCRIPTION
The footnote links were missing in some places in the
`docs/_includes/attrs-env.adoc` file.