### PR TITLE
Hopefully accurate pointer to Roles and IDs

### DIFF
--- a/docs/produce-custom-themes-using-asciidoctor-stylesheet-factory.adoc
+++ b/docs/produce-custom-themes-using-asciidoctor-stylesheet-factory.adoc
@@ -152,6 +152,13 @@ include::{includedir}/apply-theme.adoc[]
 
 Happy theming!
 
+== Specify CSS class or id
+
+An important feature to learn when customizing a CSS is that the desired CSS `class` or `id` can be specified on Asciidoc elements via 
+a {user-ref}/#role[Role] or {user-ref}/#id[ID].
+
+NOTE: It is not necessary to use a stylesheet factory to leverage Roles or IDs and specify CSS `class` or `id` on Asciidoc elements.
+
 == Additional themes for Asciidoctor
 
 The https://github.com/darshandsoni/asciidoctor-skins[asciidoctor-skins] repository has additional stylesheets that can be used to theme your AsciiDoc-based documentation.

--- a/docs/produce-custom-themes-using-asciidoctor-stylesheet-factory.adoc
+++ b/docs/produce-custom-themes-using-asciidoctor-stylesheet-factory.adoc
@@ -154,7 +154,7 @@ Happy theming!
 
 == Specify CSS class or id
 
-An important feature to learn when customizing a CSS is that the desired CSS `class` or `id` can be specified on Asciidoc elements via 
+An important feature to learn when customizing a CSS is that the desired CSS `class` or `id` can be specified on AsciiDoc elements via 
 a {user-ref}/#role[Role] or {user-ref}/#id[ID].
 
 NOTE: It is not necessary to use a stylesheet factory to leverage Roles or IDs and specify CSS `class` or `id` on Asciidoc elements.


### PR DESCRIPTION
Here's where I looked for ways to specify the CSS class or id in asciidoctor syntax.  I was falsely confident that if it wasn't mentioned here it likely didn't exist.

In the end I'm using JBake and don't need the stylesheet factory.  I made the note that the stylesheet factory wasn't necessary as I'm the kind of person who would learn it was necessary as this was preceded by instructions on how to set the stylesheet factory. (yes, it's super easy for me to take a wrong turn!! :) )