### PR TITLE
fix word repetition in callout-xml.adoc

### DIFF
--- a/docs/_includes/callout-xml.adoc
+++ b/docs/_includes/callout-xml.adoc
@@ -5,7 +5,7 @@ Included in:
 ////
 
 XML doesn't have line comments, so our "`tuck the callout behind a line comment`" trick doesn't work here.
-To use callouts in XML, you must place the callout's angled brackets around the the XML comment and callout number.
+To use callouts in XML, you must place the callout's angled brackets around the XML comment and callout number.
 
 Here's how it appears in a listing:
 


### PR DESCRIPTION
Hi Dan, thanks for merging [PR#910](https://github.com/asciidoctor/asciidoctor.org/pull/910).
To enhance readability of the user guide, I also deleted the repeated article 'the' in the Callouts chapter.