### PR TITLE
Update documentation for callouts in HTML code

### DIFF
--- a/docs/_includes/ex-callout.adoc
+++ b/docs/_includes/ex-callout.adoc
@@ -15,7 +15,7 @@ line of code  <!--4-->
 <1> A callout behind a line comment for C-style languages.
 <2> A callout behind a line comment for Ruby, Python, Perl, etc.
 <3> A callout behind a line comment for Clojure.
-<4> A callout behind a line comment for HTML
+<4> A callout behind a line comment for XML or SGML languages like HTML
 // end::b-nonselect[]
 
 // tag::source-xml[]

--- a/docs/_includes/ex-callout.adoc
+++ b/docs/_includes/ex-callout.adoc
@@ -10,10 +10,12 @@ Included in:
 line of code  // <1>
 line of code  # <2>
 line of code  ;; <3>
+line of code  <!--4-->
 ----
 <1> A callout behind a line comment for C-style languages.
 <2> A callout behind a line comment for Ruby, Python, Perl, etc.
 <3> A callout behind a line comment for Clojure.
+<4> A callout behind a line comment for HTML
 // end::b-nonselect[]
 
 // tag::source-xml[]

--- a/docs/_includes/ex-callout.adoc
+++ b/docs/_includes/ex-callout.adoc
@@ -15,7 +15,7 @@ line of code  <!--4-->
 <1> A callout behind a line comment for C-style languages.
 <2> A callout behind a line comment for Ruby, Python, Perl, etc.
 <3> A callout behind a line comment for Clojure.
-<4> A callout behind a line comment for XML or SGML languages like HTML
+<4> A callout behind a line comment for XML or SGML languages like HTML.
 // end::b-nonselect[]
 
 // tag::source-xml[]


### PR DESCRIPTION
I tried using callouts in HTML source code, but the syntax is a little different, as I found out in this issue: asciidoctor/asciidoctor#1608. I thought this could be documented