### PR TITLE
Asciidoctor reveal.js version bump

### DIFF
--- a/docs/asciidoctor-revealjs.adoc
+++ b/docs/asciidoctor-revealjs.adoc
@@ -1,6 +1,6 @@
 // NOTE include file is not resolved when reading the header only, hence the extra attributes
-:doctitle: Asciidoctor Reveal.js
-:revnumber: 3.1.0
+:doctitle: Asciidoctor reveal.js
+:revnumber: 4.0.1
 :gitref: v{revnumber}
 :keywords: Asciidoctor reveal.js, AsciiDoc, Asciidoctor, reveal.js, slides
 :page-keywords: {keywords}


### PR DESCRIPTION
4.0.0 was missing the npm package by mistake so I had to do a 4.0.1 because apparently you can't replace an unpublished npm package even 5 minutes after the initial upload