### PR TITLE
Git should ignore files used by rbenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 /vendor/
 Gemfile.lock
 .idea
-
+.ruby-version


### PR DESCRIPTION
It would ease the live of people who use rbenv to manage their Ruby installations, if files used by rbenv as `.ruby-version` would be ignored by Git.