### PR TITLE
Fix markdown syntax for cross referencing

### DIFF
--- a/docs/asciidoc-vs-markdown.adoc
+++ b/docs/asciidoc-vs-markdown.adoc
@@ -173,7 +173,7 @@ link:{site-url}/assets/mydoc.pdf[get the PDF]
 a|
 [source,markdown]
 ----
-See link:#_usage[Usage].
+See [Usage](#_usage).
 
 <h2 id="_usage">Usage</h2>
 ----


### PR DESCRIPTION
`link:#_usage[Usage]` is AsciiDoc syntax.