### PR TITLE
add note that outfilesuffix defaults to source file extension on GitLab too

### DIFF
--- a/docs/_includes/xref-source-to-source.adoc
+++ b/docs/_includes/xref-source-to-source.adoc
@@ -23,8 +23,8 @@ We could also write the link as link:README{outfilesuffix}[README].
 
 The links in the generated document will now point to [.path]_README.adoc_ instead of the default, [.path]_README.html_.
 
-TIP: This configuration is no longer necessary on GitHub since GitHub now sets the value of `outfilesuffix` to match the file extension of the source file.
-However, it's still required in GitHub-like environments such as GitLab.
+TIP: This configuration is no longer necessary on GitHub and GitLab since they set the value of `outfilesuffix` to match the file extension of the source file.
+However, it may still be required in other GitHub-like environments.
 
 CAUTION: You probably don't want to set `outfilesuffix` to `.adoc` without the `ifdef` condition as it could result in Asciidoctor overwriting input files when you run it locally (though there's some protection against this).
 


### PR DESCRIPTION
Similar to a6fae10141625782d0a2dda8f4af3419187de09f. The correct `outfilesuffix` setting has been [implemented](https://gitlab.com/gitlab-org/gitlab/-/commit/9a450aedc2c81f8ce17e4c9b4238c58edbef8269) in GitLab for over two years now.