### PR TITLE
Add documentation for docinfo header

### DIFF
--- a/docs/_includes/docinfo.adoc
+++ b/docs/_includes/docinfo.adoc
@@ -154,7 +154,7 @@ To specify which file(s) you want to apply, set the `docinfo` attribute to any c
 * `shared-head`
 * `shared-header`
 * `shared-footer`
-* `shared` (alias for `shared-head,shared-footer`)
+* `shared` (alias for `shared-head,shared-header,shared-footer`)
 
 Setting `docinfo` with no value is equivalent to setting the value to `private`.
 

--- a/docs/_includes/docinfo.adoc
+++ b/docs/_includes/docinfo.adoc
@@ -83,6 +83,15 @@ See <<Naming docinfo files>> for more details.
 
 To see a real-world example of a docinfo file for DocBook, checkout the {richfaces-docinfo}[RichFaces Developer Guide docinfo file].
 
+=== Header docinfo files
+
+Header docinfo files are differentiated from head docinfo files by the addition of `-header` to the file name.
+In the HTML output, the header content is inserted immediately before the header div (i.e., `<div id="header">`).
+In the DocBook output, the header content is inserted immediately after the opening tag (e.g., `<article>` or `<book>`).
+
+TIP: One possible use of the header docinfo file is to completely replace the default header in the standard stylesheet.
+Just set the attribute `noheader`, then apply a custom header docinfo file.
+
 === Footer docinfo files
 
 Footer docinfo files are differentiated from head docinfo files by the addition of `-footer` to the file name.
@@ -114,6 +123,10 @@ The file extension of the docinfo file must match the file extension of the outp
 |Adds content to `<head>`/`<info>` for <docname>.adoc files.
 |`<docname>-docinfo<outfilesuffix>`
 
+|Header
+|Adds content to start of document for <docname>.adoc files.
+|`<docname>-docinfo-header<outfilesuffix>`
+
 |Footer
 |Adds content to end of document for <docname>.adoc files.
 |`<docname>-docinfo-footer<outfilesuffix>`
@@ -123,6 +136,10 @@ The file extension of the docinfo file must match the file extension of the outp
 |Adds content to `<head>`/`<info>` for any document in same directory.
 |`docinfo<outfilesuffix>`
 
+|Header
+|Adds content to start of document for any document in same directory.
+|`docinfo-header<outfilesuffix>`
+
 |Footer
 |Adds content to end of document for any document in same directory.
 |`docinfo-footer<outfilesuffix>`
@@ -131,9 +148,11 @@ The file extension of the docinfo file must match the file extension of the outp
 To specify which file(s) you want to apply, set the `docinfo` attribute to any combination of these values:
 
 * `private-head`
+* `private-header`
 * `private-footer`
-* `private` (alias for `private-head,private-footer`)
+* `private` (alias for `private-head,private-header,private-footer`)
 * `shared-head`
+* `shared-header`
 * `shared-footer`
 * `shared` (alias for `shared-head,shared-footer`)
 
@@ -146,7 +165,7 @@ For example:
 :docinfo: shared,private-footer
 ----
 
-This docinfo configuration will apply the shared docinfo head and footer files, if they exist, as well as the private footer file, if it exists.
+This docinfo configuration will apply the shared docinfo head, header and footer files, if they exist, as well as the private footer file, if it exists.
 
 // NOTE migrate this NOTE to the migration guide once 1.6 is released
 [NOTE]


### PR DESCRIPTION
In https://github.com/asciidoctor/asciidoctor/issues/1720 a docinfo header was introduced, but this was not documented in the user manual.