### PR TITLE
Update Awestruct to 0.6.1, Asciidoctor to 2.0.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@
 
 source 'https://rubygems.org'
 
-gem 'awestruct', '0.5.7'
+gem 'awestruct', '0.6.1'
 #gem 'awestruct', github: 'awestruct/awestruct', branch: 'master'
-gem 'asciidoctor', '1.5.7.1'
+gem 'asciidoctor', '2.0.10'
 #gem 'asciidoctor-diagram', '1.4.0'
 gem 'chunky_png', '1.3.5'
 gem 'coderay', '1.1.1'

--- a/docs/asciidoctor-gradle-plugin.adoc
+++ b/docs/asciidoctor-gradle-plugin.adoc
@@ -1,7 +1,7 @@
 // NOTE include file is not resolved when reading the header only, hence the extra attributes
 :doctitle: Asciidoctor Gradle Plugin
-:revnumber: 1.5.9.2
-:gitref: release_1_5_9_2
+:revnumber: 3.2.0
+:gitref: release_3_2_0
 :keywords: Gradle plugin, AsciidoctorJ, Asciidoctor, Java, build
 :page-keywords: {keywords}
 :page-layout: docs


### PR DESCRIPTION
For Awestruct changelog see https://github.com/awestruct/awestruct/releases

The change in  `docs/asciidoctor-gradle-plugin.adoc` is to make sure new Asciidoctor doesn't show warnings about `footnoteref` used in the old version of the Gradle plugin readme.