### PR TITLE
Update Gradle plugin reference to 3.2.0

### DIFF
--- a/docs/asciidoctor-gradle-plugin.adoc
+++ b/docs/asciidoctor-gradle-plugin.adoc
@@ -1,7 +1,7 @@
 // NOTE include file is not resolved when reading the header only, hence the extra attributes
 :doctitle: Asciidoctor Gradle Plugin
-:revnumber: 1.5.9.2
-:gitref: release_1_5_9_2
+:revnumber: 3.2.0
+:gitref: release_3_2_0
 :keywords: Gradle plugin, AsciidoctorJ, Asciidoctor, Java, build
 :page-keywords: {keywords}
 :page-layout: docs


### PR DESCRIPTION
As of this writing 3.2.0 is the latest version of the plugin.
https://github.com/asciidoctor/asciidoctor-gradle-plugin/releases

This PR was formerly part of #950 .

cc @ysb33r 