### PR TITLE
Specify that explicit ids are asciidoctor only

### DIFF
--- a/docs/asciidoc-syntax-quick-reference.adoc
+++ b/docs/asciidoc-syntax-quick-reference.adoc
@@ -275,7 +275,7 @@ The reader never sees the extra markup, so why type it?
 *Be frugal!*
 ////
 
-.Explicit id
+.Explicit id (Asciidoctor only)
 ----
 [#primitives-nulls]
 == Primitive types and null values


### PR DESCRIPTION
asciidoc-py does not support explicit ids and attempting to use them causes errors on parsing. For example, given the following file:

```asciidoc
= Hello

[#primitives-nulls]
== Primitive types and null values
```

gives the following when attempted to be translated by asciidoc-py:

```
$ python3 ../asciidoc-py3/asciidoc.py test.asciidoc
asciidoc: WARNING: test.asciidoc: line 4: missing section: [#explicit-id]
```

and the resulting file does not have the second header at all. Asciidoctor handles this as documented, with the second header appearing and with an explicitly set id.