### PR TITLE
feat(editing-asciidoc-with-live-preview.): Add vscode

### DIFF
--- a/docs/editing-asciidoc-with-live-preview.adoc
+++ b/docs/editing-asciidoc-with-live-preview.adoc
@@ -75,6 +75,17 @@ https://atom.io/packages/asciidoc-image-helper[AsciiDoc Image Helper] :: provide
 https://atom.io/packages/autocomplete-asciidoc[AsciiDoc Autocomplete] :: automatically completes AsciiDoc language items
 https://atom.io/packages/asciidoc-assistant[AsciiDoc Assistant] :: Installs useful components to Atom for editing AsciiDoc files (including the above packages)
 
+=== Visual Studio Code
+
+Install https://code.visualstudio.com/[Visual Studio Code].
+Then from the Visual Studio Code view menu, select Extensions.
+Enter "Asciidoctor" as the search term.
+Browse the asciidoctor extensions and install "Asciidoc" by João Pinto.
+
+More information:
+
+* https://github.com/asciidoctor/asciidoctor-vscode[Asciidoctor VSCode]
+
 === Brackets
 
 Install http://brackets.io/[Brackets].


### PR DESCRIPTION
Add Visual Studio Code as being an editor with Asciidoc preview capability.
The language has been kept the same as for Brackets.
Nothing more needed than signposting that VSCode is suitable.