### PR TITLE
Fix typo SAFE --> UNSAFE

### DIFF
--- a/docs/_includes/uri-include.adoc
+++ b/docs/_includes/uri-include.adoc
@@ -26,7 +26,7 @@ Here's an example that shows how to run Asciidoctor from the console so it can r
 
  $ asciidoctor -a allow-uri-read filename.adoc
 
-Remember that Asciidoctor executes in SAFE mode by default when run from the command line.
+Remember that Asciidoctor executes in UNSAFE mode by default when run from the command line.
 
 Here's an example that shows how to run Asciidoctor from the API so it can read content from a URI:
 


### PR DESCRIPTION
As per my tests, and the rest of the docs, when run from the CLI, AsciiDoctor runs in UNSAFE mode. 

https://asciidoctor.org/docs/user-manual/#set-the-safe-mode-in-the-cli
"When Asciidoctor is invoked via the CLI, the safe mode is set to UNSAFE by default." This is indeed correct as per my tests.