### PR TITLE
Fix typo in unordered list example

### DIFF
--- a/docs/_includes/ex-ulist.adoc
+++ b/docs/_includes/ex-ulist.adoc
@@ -8,20 +8,20 @@ Included in:
 ////
 
 // tag::base[]
-* Edgar Allen Poe
+* Edgar Allan Poe
 * Sheri S. Tepper
 * Bill Bryson
 // end::base[]
 
 // tag::base-t[]
 .Kizmet's Favorite Authors
-* Edgar Allen Poe
+* Edgar Allan Poe
 * Sheri S. Tepper
 * Bill Bryson
 // end::base-t[]
 
 // tag::base-alt[]
-- Edgar Allen Poe
+- Edgar Allan Poe
 - Sheri S. Tepper
 - Bill Bryson
 // end::base-alt[]


### PR DESCRIPTION
This is only to fix small typo in Edgar Allan Poe's name in AsciiDoctor unordered list example.