### PR TITLE
Fix small typos in the text of Writer's Guide

### DIFF
--- a/docs/_includes/ulist-complex.adoc
+++ b/docs/_includes/ulist-complex.adoc
@@ -7,7 +7,7 @@ Included in:
 
 Aside from nested lists, all of the list items you've seen only have one line of text.
 But like with regular paragraph text, the text in a list item can wrap across any number of lines, as long as all the lines are adjacent.
-The wrapped lines can be indented and they will still be treated as normal paragraph text.
+The wrapped lines can be indented, and they will still be treated as normal paragraph text.
 For example:
 
 [source]
@@ -117,7 +117,7 @@ include::ex-ulist.adoc[tag=complex-only]
 ==== Attaching to an ancestor list
 
 You may find that you need to attach block content to a parent list item instead of the current one.
-In other words, you want to attach the block content to the parent list item so it becomes a sibling of the child list.
+In other words, you want to attach the block content to the parent list item, so it becomes a sibling of the child list.
 To do this, you add a blank line before the list continuation.
 The blank line signals to the list continuation to move out of the current list so it attaches the block to the last item of the parent list.
 

--- a/docs/asciidoc-writers-guide.adoc
+++ b/docs/asciidoc-writers-guide.adoc
@@ -369,7 +369,7 @@ include::{includedir}/xref-relative.adoc[]
 In the link that is created from the inter-document cross reference, the source file extension is replaced with the value of the `outfilesuffix` attribute.
 To customize the file extension used in the target of the link, simply change the value of this attribute.
 
-Image references are similar to links since they are also references to URLs or files.
+Image references are similar to links since they are also referencing to URLs or files.
 The difference, of course, is that they display the image in the document.
 
 ==== Images
@@ -455,7 +455,7 @@ According to Wikipedia...
 ----
 
 The document title is part of the document header.
-So what else can go in the header?
+So, what else can go in the header?
 Good question.
 
 ===== The document header
@@ -1132,7 +1132,7 @@ You can also define the `header` option using the following shorthand:
 [%header,cols=2*]
 ```
 
-Alternatively, we could define the header row on a single line offset from the body rows by a blank line so neither the `cols` or the `options` attributes are required.
+Alternatively, we could define the header row on a single line offset from the body rows by a blank line, so neither the `cols` nor the `options` attributes are required.
 
 [source]
 ----
@@ -1316,7 +1316,7 @@ The Asciidoctor processor parses the document and translates it into a backend f
 Asciidoctor ships with a set of default templates in the tin, but you can customize the templates or create your own to get exactly the output you want.
 
 Before you can use the Asciidoctor processor, you have to install the {asciidoctor-gem-ref}[Asciidoctor Ruby Gem].
-Review the {uri-install}[Asciidoctor Installation Guide] if you need helping installing the gem.
+Review the {uri-install}[Asciidoctor Installation Guide] if you need help to install the gem.
 
 === Converting a document to HTML 5
 


### PR DESCRIPTION
These are only small fixes of minor typos that I've found in the text while studying it. :-)