### PR TITLE
Fixed Rouge install instructions for Debian-based systems

### DIFF
--- a/docs/_includes/src-rouge.adoc
+++ b/docs/_includes/src-rouge.adoc
@@ -13,9 +13,9 @@ Install using `gem` (all systems)::
 +
  $ gem install rouge
 
-Install using `apt-get` (Debian-based systems)::
+Install using `apt` (Debian-based systems)::
 +
- $ sudo apt-get install rouge
+ $ sudo apt install ruby-rouge
 
 Install using `dnf` (Fedora-based systems)::
 +

--- a/docs/_includes/src-rouge.adoc
+++ b/docs/_includes/src-rouge.adoc
@@ -13,9 +13,9 @@ Install using `gem` (all systems)::
 +
  $ gem install rouge
 
-Install using `apt` (Debian-based systems)::
+Install using `apt-get` (Debian-based systems)::
 +
- $ sudo apt install ruby-rouge
+ $ sudo apt-get install ruby-rouge
 
 Install using `dnf` (Fedora-based systems)::
 +


### PR DESCRIPTION
I fixed the Rouge installation instructions in the manual as they weren't working on my Ubuntu. I can't check on a pure Debian but I double-checked the name of the package in the following archives

https://packages.debian.org/search?keywords=ruby-rouge
https://packages.ubuntu.com/search?keywords=ruby-rouge&searchon=names&suite=all&section=all

Thanks for Asciidoctor, a great piece of software!