### PR TITLE
List asciidoctor-p2e extension

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -154,4 +154,8 @@ Each cell is formatted as an AsciiDoc table cell content, so the event can inclu
 |https://puravida-asciidoctor.gitlab.io/asciidoctor-quizzes/[Quiz]
 |AsciidoctorJ
 |An *experimental* extension to generate interactive quizzes.
+
+|https://bosco.srht.site/asciidoctor-p2e.html[Asciidoctor P2E]
+|Asciidoctor
+|Makes it easier to create content for the Pathfinder 2E roleplaying system.
 |====


### PR DESCRIPTION
This extension adds a block that you can use to create Pathfinder 2E statblocks. More info about the extension can be found at https://bosco.srht.site/asciidoctor-p2e.html and https://using.tech/posts/p2e/.