### PR TITLE
Redirect maven docs to docs.aciidoctor.org

### DIFF
--- a/_ext/routers/asciidoctor-maven-plugin.js
+++ b/_ext/routers/asciidoctor-maven-plugin.js
@@ -1,0 +1,24 @@
+var idMapping = {
+    '': '/maven-tools/latest/',
+    'maven-plugin': '/maven-tools/latest/introduction/',
+    'setup': '/maven-tools/latest/plugin/goals/process-asciidoc/#setup',
+    'configuration': '/maven-tools/latest/plugin/goals/process-asciidoc/#configuration',
+    'built-in-attributes': '/maven-tools/latest/plugin/goals/process-asciidoc/#configuration-attributes',
+    'passing-pom-properties': '/maven-tools/latest/plugin/goals/process-asciidoc/#configuration',
+    'setting-boolean-values': '/maven-tools/latest/plugin/goals/process-asciidoc/#configuration-attributes',
+    'command-line-configuration': '/maven-tools/latest/plugin/command-line-configuration/',
+    'multiple-outputs-for-the-same-file': '/maven-tools/latest/plugin/usage/#multiple-outputs-for-the-same-file',
+    'maven-site-integration': '/maven-tools/latest/site-integration/',
+    'setup-2': '/maven-tools/latest/site-integration/#setup',
+    'configuration-2': '/maven-tools/latest/site-integration/#configuration',
+    'hacking': '/maven-tools/latest/project/contributing/#hacking',
+    'building': '/maven-tools/latest/project/contributing/#hacking',
+    'testing': '/maven-tools/latest/project/contributing/#testing',
+    'tips-tricks': '/maven-tools/latest/plugin/tips-and-tricks/',
+    'generate-your-documentation-in-separate-folders-per-version': '/maven-tools/latest/plugin/tips-and-tricks/#generate-your-documentation-in-separate-folders-per-version',
+    'enable-section-numbering': '/maven-tools/latest/plugin/tips-and-tricks/#enable-section-numbering',
+    'add-version-and-build-date-to-the-header': '/maven-tools/latest/plugin/tips-and-tricks/#add-version-and-build-date-to-the-header',
+}
+
+var hash = window.location.hash
+window.location.href = 'https://docs.asciidoctor.org' + ((hash && idMapping[hash.slice(1)]) || (idMapping[''] + hash))

--- a/_ext/routers/hack-asciidoctor-maven-plugin.js
+++ b/_ext/routers/hack-asciidoctor-maven-plugin.js
@@ -1,0 +1,10 @@
+var idMapping = {
+    '': '/maven-tools/latest/project/contributing/',
+    'hacking': '/maven-tools/latest/project/contributing/#hacking',
+    'building': '/maven-tools/latest/project/contributing/#hacking',
+    'testing': '/maven-tools/latest/project/contributing/#testing',
+    'resources': '/maven-tools/latest/project/contributing/#testing',
+}
+
+var hash = window.location.hash
+window.location.href = 'https://docs.asciidoctor.org' + ((hash && idMapping[hash.slice(1)]) || (idMapping[''] + hash))


### PR DESCRIPTION
Adds redirections for */docs/asciidoctor-maven-plugin* and */docs/hack-asciidoctor-maven-plugin* to the new docs site (docs.asciidoctor.org/).

Note that:
* Not all links have a direct translation because some sections were removed. For example, the attributes and "building".
* This depends on this PR https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/509. @mojavelinux I recall docs need to be rebuild after the merge?