### PR TITLE
Separate document revision remark with a colon

### DIFF
--- a/docs/_includes/asciidoc-article-template.adoc
+++ b/docs/_includes/asciidoc-article-template.adoc
@@ -1,6 +1,6 @@
 = AsciiDoc Article Title
 Firstname Lastname <author@asciidoctor.org>
-3.0, July 29, 2022, AsciiDoc article template
+3.0, July 29, 2022: AsciiDoc article template
 :toc:
 :icons: font
 :url-quickref: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/


### PR DESCRIPTION
If I read [the documentation about the revision line](https://docs.asciidoctor.org/asciidoc/latest/document/revision-line/#when-can-i-use-the-revision-line) correctly, then the revision's remark should be separated from the date by a colon, and not a comma, as is done in the template.

This change would fix this mistake.