### PR TITLE
Update asciidoc-writers-guide.adoc

### DIFF
--- a/docs/asciidoc-writers-guide.adoc
+++ b/docs/asciidoc-writers-guide.adoc
@@ -268,7 +268,7 @@ The role can be used to apply custom styling to the text.
 For instance:
 
 [source]
-Type the word [.userinput]#asciidoc# into the search bar.
+Type the word [userinput]#asciidoc# into the search bar.
 
 When converting to HTML, the word "`asciidoc`" is wrapped in `<span>` tags and the role is used as the element's CSS class:
 


### PR DESCRIPTION
I installed `asciidoc 10.2.1` from AUR and ran the example from the docs.

The docs claim that 
```
[.userinput]#asciidoc#
```
generates

```
<span class="userinput">asciidoc</span>
```

but in fact it generates

```
<span class=".userinput">asciidoc</span>
```

which leads me to believe you need to leave out the . in the square brackets.