### PR TITLE
docs: add asciidoctor-lists-extended, dot-leader, and rhrev extensions

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -181,4 +181,16 @@ Each cell is formatted as an AsciiDoc table cell content, so the event can inclu
 |https://github.com/Alwinator/asciidoctor-lists[Asciidoctor Lists]
 |Asciidoctor
 |An asciidoctor extension that adds a list of figures, a list of tables, or a list of anything you want!
+
+|https://gitlab.com/baiyibai-asciidoc/asciidoctor-lists-extended[Asciidoctor Lists Extended]
+|Asciidoctor, Asciidoctor PDF
+|Provides ToC-styled lists for the PDF converter, backwards compatible with asciidoctor-lists.
+
+|https://gitlab.com/baiyibai-asciidoc/asciidoctor-dot-leader[Asciidoctor Dot Leader]
+|Asciidoctor, Asciidoctor PDF
+|Provides typographic dot leaders between two items.
+
+|https://gitlab.com/baiyibai-asciidoc/rhrev-asciidoctor-automatic-revision-history[Asciidoctor RHRev]
+|Asciidoctor, Asciidoctor PDF
+|Creates a grouped, formatted table of document changes.
 |====


### PR DESCRIPTION
Adds three third-party extensions to the extensions catalog, as invited in
https://github.com/asciidoctor/asciidoctor.org/issues/1043#issuecomment-4275200642

- asciidoctor-lists-extended: ToC-styled lists for the PDF converter
- asciidoctor-dot-leader: typographic dot leaders between two items
- asciidoctor-rhrev: grouped, formatted table of document changes

Closes asciidoctor/asciidoctor.org#1043